### PR TITLE
Experiment: Remove explicit token parameters from workflows

### DIFF
--- a/.github/workflows/greet.yml
+++ b/.github/workflows/greet.yml
@@ -15,7 +15,6 @@ jobs:
     steps:
       - uses: actions/first-interaction@v3
         with:
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
           issue_message: |
             👋 Thanks for opening your first issue! We appreciate your contribution to requirements-expert.
 

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -15,7 +15,6 @@ jobs:
     steps:
       - uses: actions/stale@v10
         with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
           stale-issue-message: 'This issue has been automatically marked as stale because it has not had recent activity. It will be closed if no further activity occurs. Thank you for your contributions.'
           stale-pr-message: 'This PR has been automatically marked as stale because it has not had recent activity. It will be closed if no further activity occurs.'
           close-issue-message: 'This issue was closed because it has been stale for 7 days with no activity.'


### PR DESCRIPTION
## Purpose

This is an **experimental PR** to test whether explicit token parameters are necessary or if the actions work correctly with their default values.

## Changes

- Removed `repo-token: ${{ secrets.GITHUB_TOKEN }}` from stale.yml
- Removed `repo_token: ${{ secrets.GITHUB_TOKEN }}` from greet.yml

## Hypothesis

Both actions should work correctly because:
1. Both have `default: ${{ github.token }}` in their action.yml
2. Both workflows have explicit `permissions:` blocks granting necessary access
3. Official documentation doesn't show explicit token in examples

## What We're Testing

If this PR's checks pass and the workflows validate correctly, it confirms:
- ✅ Explicit token parameters are redundant
- ✅ Actions use their defaults correctly
- ✅ Workflows can be cleaner and more concise

If checks fail, it confirms:
- ❌ Explicit tokens are necessary despite defaults
- ❌ We should revert and keep the current approach

## Expected Outcome

The workflow validation check should pass, proving the syntax is correct even without explicit tokens.

**Note**: We won't be able to fully test greet.yml (only triggers on first-time contributors) or stale.yml (runs on schedule), but syntax validation passing is a good indicator.

---

**This is safe to test** - if it doesn't work, we simply close this PR and keep the explicit tokens.