### PR TITLE
Remove unused .mcp.json and GitHub MCP server references

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -11,7 +11,7 @@
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] Documentation update (improvements to README, CLAUDE.md, or component docs)
 - [ ] Refactoring (code change that neither fixes a bug nor adds a feature)
-- [ ] Configuration change (changes to .markdownlint.json, .mcp.json, etc.)
+- [ ] Configuration change (changes to .markdownlint.json, plugin.json, etc.)
 
 ## Component(s) Affected
 
@@ -22,7 +22,7 @@
 - [ ] Agents (requirements-assistant, requirements-validator)
 - [ ] Hooks (UserPromptSubmit)
 - [ ] Documentation (README.md, CLAUDE.md, SECURITY.md)
-- [ ] Configuration (.markdownlint.json, .mcp.json, plugin.json, marketplace.json)
+- [ ] Configuration (.markdownlint.json, plugin.json, marketplace.json)
 - [ ] Issue/PR templates
 - [ ] Other (please specify):
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,9 +43,8 @@ This repository uses a **marketplace-at-root** structure where the repository ac
 │       ├── commands/                # 8 slash commands (*.md)
 │       ├── skills/                  # 6 knowledge modules (*/SKILL.md)
 │       ├── agents/                  # 2 specialized agents (*.md)
-│       ├── hooks/
-│       │   └── hooks.json           # UserPromptSubmit hook
-│       └── .mcp.json                # GitHub CLI MCP server config
+│       └── hooks/
+│           └── hooks.json           # UserPromptSubmit hook
 ├── README.md                        # User-facing documentation
 └── CLAUDE.md                        # This file (development docs)
 ```
@@ -315,7 +314,7 @@ gh project list --owner [owner]   # List existing projects
 
 ## GitHub CLI Integration
 
-All commands use `gh` CLI for GitHub operations via the Bash tool. The `.mcp.json` configures a GitHub MCP server but commands primarily use direct CLI calls.
+All commands use `gh` CLI for GitHub operations via the Bash tool. This is the plugin's **only external dependency**.
 
 ### Critical Commands
 

--- a/plugins/requirements-expert/.mcp.json
+++ b/plugins/requirements-expert/.mcp.json
@@ -1,9 +1,0 @@
-{
-  "mcpServers": {
-    "github": {
-      "command": "gh",
-      "args": ["mcp"],
-      "env": {}
-    }
-  }
-}


### PR DESCRIPTION
## Description

This PR removes the non-functional .mcp.json configuration file and all references to the GitHub MCP server throughout the codebase.

## Type of Change

- [x] Bug fix (removes broken configuration)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update (improvements to README, CLAUDE.md, or component docs)
- [x] Configuration change (removal of .mcp.json)
- [ ] Refactoring (code change that neither fixes a bug nor adds a feature)

## Component(s) Affected

- [ ] Commands (`/requirements:*`)
- [ ] Skills (methodology and best practices)
- [ ] Agents (requirements-assistant, requirements-validator)
- [ ] Hooks (UserPromptSubmit)
- [x] Documentation (CLAUDE.md)
- [x] Configuration (removed .mcp.json)
- [x] Issue/PR templates (updated to remove .mcp.json reference)
- [ ] Other (please specify):

## Motivation and Context

**Problem Discovered**: The .mcp.json file was broken and never actually used:
- Configured `gh mcp` command which **doesn't exist**
- Caused MCP server failures when users installed the plugin
- Zero commands or agents actually use MCP tools
- All 8 commands use gh CLI directly via Bash tool
- Plugin works perfectly without it

**Root Cause Analysis**:
The .mcp.json was likely copy-pasted from an example but:
- Never properly configured (gh mcp isn't a real command)
- Never integrated into commands (no MCP tool usage)
- Never tested (would have failed immediately)
- Created false expectation that MCP server was needed

## Changes

**Removed**:
- `plugins/requirements-expert/.mcp.json` - Broken MCP configuration
- MCP server reference in CLAUDE.md repository structure diagram
- MCP server reference in CLAUDE.md GitHub CLI Integration section  
- .mcp.json references in PR template (2 instances)

**Updated**:
- CLAUDE.md: Clarified gh CLI is the ONLY external dependency
- Documentation now accurate about what's actually required

## Benefits

✅ **Simpler installation** - No MCP server confusion
✅ **Removes broken code** - Eliminates non-working configuration
✅ **Honest documentation** - Says what's actually used
✅ **Fewer failure points** - One dependency instead of trying to set up two
✅ **Easier troubleshooting** - Users only need to verify gh CLI works

## How Has This Been Tested?

**Test Configuration**:
- Claude Code version: Latest
- GitHub CLI version: gh version 2.62.0
- OS: macOS 14.7
- Testing repository: sjnims/requirements-expert

**Test Steps**:
1. Removed .mcp.json file
2. Updated all documentation references
3. Verified no commands use MCP tools (searched entire codebase)
4. Confirmed all commands use Bash + gh CLI
5. Ran markdownlint on changed files
6. Tested plugin still works: `cc --plugin-dir plugins/requirements-expert`

## Checklist

### General

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas (if applicable)
- [x] My changes generate no new warnings or errors

### Documentation

- [x] I have updated the documentation accordingly (CLAUDE.md, PR template)
- [x] I have updated YAML frontmatter (if applicable)
- [x] I have verified all links work correctly

### Markdown

- [x] I have run `markdownlint` and fixed all issues
- [x] My markdown follows the repository style (ATX headers, dash lists, fenced code blocks)
- [x] I have verified special HTML elements are properly closed

### Testing

- [x] I have tested the plugin locally with `cc --plugin-dir plugins/requirements-expert`
- [x] Plugin works identically without .mcp.json (as expected - it was never used)

## Additional Notes

**Why gh CLI via Bash is sufficient**:
- Simple CRUD operations (create issues, list projects, set fields)
- Well-documented GitHub CLI commands
- No complex AI orchestration needed
- Users already must have gh CLI installed
- Portable across all environments

**When MCP would be useful** (not applicable to us):
- Complex multi-step GitHub workflows
- Heavy code analysis and searching  
- Advanced AI orchestration needs
- Apps where GitHub features are primary focus

For our use case (simple requirements management using GitHub Projects as storage), direct gh CLI usage is simpler, more reliable, and easier to troubleshoot.