### PR TITLE
docs: Add comprehensive testing strategies to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -331,6 +331,111 @@ markdownlint plugins/requirements-expert/commands/*.md  # Check specific files
 - **Add to existing**: Commands detect existing items and offer to add more
 - **Validation**: Run `/re:review` to check for issues
 
+### Comprehensive Testing Strategies
+
+This section provides detailed testing strategies for contributors who are creating or modifying commands before deployment and distribution.
+
+#### Testing `/re:init` Command
+
+**1. Happy Path Testing**:
+- [ ] Load plugin: `cc --plugin-dir plugins/requirements-expert`
+- [ ] Navigate to a test git repository with GitHub remote
+- [ ] Run `/re:init`
+- [ ] Verify project created with user-selected name
+- [ ] Verify all three custom fields exist: Type, Priority, Status
+- [ ] Verify field options are correct:
+  - Type: Vision, Epic, Story, Task
+  - Priority: Must Have, Should Have, Could Have, Won't Have
+  - Status: Not Started, In Progress, Completed
+- [ ] Verify success message displays with project URL and next steps
+
+**2. Idempotency Testing**:
+- [ ] Run `/re:init` again in the same repository
+- [ ] Verify no duplicate project created (reuses existing)
+- [ ] Verify no duplicate fields created (skips existing)
+- [ ] Verify appropriate "already exists" messages displayed
+- [ ] Verify command completes successfully
+
+**3. Error Cases - Prerequisites Validation**:
+- [ ] Test without `gh` CLI installed:
+  - Expected: Clear error message suggesting installation
+  - Verify: `brew install gh` or link to <https://cli.github.com/>
+- [ ] Test without GitHub authentication:
+  - Expected: Error message suggesting `gh auth login`
+  - Verify: Command exits gracefully
+- [ ] Test without project scope:
+  - Expected: Error message suggesting `gh auth refresh -s project`
+  - Verify: Clear explanation of required scopes
+- [ ] Test outside git repository:
+  - Expected: Error message about not being in git repo
+  - Verify: Suggests navigating to project repository
+
+**4. Interactive Recovery Testing (Step 6)**:
+- [ ] Simulate project creation failure (invalid permissions, network issue)
+- [ ] Verify AskUserQuestion presents 3 recovery options:
+  - Retry: Try creating the project again
+  - Check permissions: Show diagnostic commands
+  - Exit: Graceful exit with manual steps
+- [ ] Test "Retry" option:
+  - Verify command re-attempts project creation
+  - If fails again, recovery options presented again
+- [ ] Test "Check permissions" option:
+  - Verify `gh auth status` output displayed
+  - Verify `gh auth refresh -s project` command shown
+  - Verify explanation of required scopes
+  - Verify recovery options presented again after diagnostics
+- [ ] Test "Exit" option:
+  - Verify graceful exit message with manual troubleshooting steps
+  - Verify original error details included
+
+**5. Field Creation Optimization Testing**:
+- [ ] Verify single field-list query executed (not 3 separate calls):
+  - Step 7 queries field list once
+  - Steps 8-10 check stored list (no additional queries)
+- [ ] Test when all fields already exist:
+  - Verify "already exists, skipping creation" for all three fields
+  - Verify no field creation commands executed
+- [ ] Test when some fields exist:
+  - Verify existing fields skipped with message
+  - Verify only missing fields created
+- [ ] Test field-list query failure:
+  - Verify graceful degradation (empty list assumption)
+  - Verify warning message displayed
+  - Verify all fields attempted to be created
+
+**6. AskUserQuestion Structure Validation**:
+- [ ] Step 4 (Project Name):
+  - Verify proper structure: question, header, multiSelect, options
+  - Verify header within 12 character limit ("Project Name" = 12)
+  - Verify 3 options with labels and descriptions
+  - Verify "Other" option available for custom input
+  - Verify repository name placeholder substitution
+
+**7. Edge Cases**:
+- [ ] Test with special characters in repository name
+- [ ] Test with very long repository name
+- [ ] Test in organization vs personal account
+- [ ] Test with existing project using exact same name
+- [ ] Test with rate limiting (many API calls in succession)
+
+#### Testing Other Commands
+
+**General Testing Pattern**:
+1. Prerequisites validation (gh CLI, auth, repo context)
+2. Happy path execution
+3. Idempotency (safe to re-run)
+4. Error handling (graceful failures)
+5. User interaction (AskUserQuestion where applicable)
+6. GitHub API integration (correct commands, error handling)
+
+**Validation Checklist**:
+- [ ] YAML frontmatter syntax correct
+- [ ] Allowed-tools list matches actual tool usage
+- [ ] Commands use proper GitHub CLI patterns (see "Critical GitHub CLI Patterns")
+- [ ] Error messages are clear and actionable
+- [ ] Success messages include next steps
+- [ ] Markdown formatting passes linting
+
 ## GitHub CLI Integration
 
 All commands use `gh` CLI for GitHub operations via the Bash tool. This is the plugin's **only external dependency**.


### PR DESCRIPTION
## Summary

This PR adds comprehensive testing strategies to CLAUDE.md for contributors who are creating or modifying commands before deployment and distribution.

## Context

Initially, issue #31 requested adding a testing checklist to the `/re:init` command's Implementation Notes section. However, we realized:
- Command files (`.md` in `commands/`) are instructions **FOR Claude Code** to execute
- `CLAUDE.md` is documentation **FOR human developers** working on the plugin
- Testing strategies are meta-documentation about plugin development

Therefore, the proper location for testing guidance is **CLAUDE.md**, not command files.

## Changes

### New Section: "Comprehensive Testing Strategies"

Added after existing "Testing Workflow" section (line 334), before "GitHub CLI Integration" section.

#### 1. Testing `/re:init` Command (7 Categories)

**Happy Path Testing**:
- Load plugin and run command
- Verify project creation with user-selected name
- Verify all three custom fields (Type, Priority, Status)
- Verify field options are correct
- Verify success message with next steps

**Idempotency Testing**:
- Run command multiple times
- Verify no duplicate project or fields created
- Verify appropriate "already exists" messages

**Error Cases - Prerequisites Validation**:
- Test without `gh` CLI installed
- Test without GitHub authentication  
- Test without project scope
- Test outside git repository
- Verify clear, actionable error messages

**Interactive Recovery Testing (Step 6)**:
- Simulate project creation failure
- Test "Retry" option (re-attempts creation)
- Test "Check permissions" option (shows diagnostics)
- Test "Exit" option (graceful exit with manual steps)

**Field Creation Optimization Testing**:
- Verify single field-list query (not 3 separate calls)
- Test when all fields already exist
- Test when some fields exist
- Test field-list query failure (graceful degradation)

**AskUserQuestion Structure Validation**:
- Verify proper structure (question, header, multiSelect, options)
- Verify header within 12 character limit
- Verify 3 options with labels and descriptions
- Verify "Other" option available
- Verify repository name placeholder substitution

**Edge Cases**:
- Special characters in repository name
- Very long repository name
- Organization vs personal account
- Existing project with same name
- Rate limiting scenarios

#### 2. Testing Other Commands

**General Testing Pattern** (6-step checklist):
1. Prerequisites validation
2. Happy path execution
3. Idempotency (safe to re-run)
4. Error handling (graceful failures)
5. User interaction (AskUserQuestion)
6. GitHub API integration

**Validation Checklist**:
- YAML frontmatter syntax correct
- Allowed-tools list matches actual usage
- Proper GitHub CLI patterns
- Clear, actionable error messages
- Success messages include next steps
- Markdown formatting passes linting

## Benefits

- ✅ **Comprehensive coverage**: All test scenarios documented
- ✅ **Contributor-friendly**: Clear checklist format
- ✅ **Validates enhancements**: Tests all recent improvements
  - Interactive error recovery (PR #34)
  - Field optimization (PR #35)
  - AskUserQuestion structure (PR #33)
- ✅ **Repeatable**: Consistent testing across contributors
- ✅ **Educational**: Documents expected behavior
- ✅ **Quality assurance**: Reduces bugs before deployment

## Documentation Updates

Also updated issue #31 to reflect:
- Correct location: CLAUDE.md (not init.md)
- Correct intent: Testing strategies for contributors
- Rationale for location change
- Updated title: "[Docs]: Add comprehensive testing strategies to CLAUDE.md"

## Validation

- ✅ Markdown linting passed
- ✅ Fixed bare URL (wrapped in angle brackets)
- ✅ Proper formatting (checklists, code blocks, headers)
- ✅ Follows existing CLAUDE.md structure
- ✅ 105 lines added with comprehensive coverage

## Related

- Fixes #31
- References testing-strategies.md from plugin-dev:command-development skill
- Complements existing "Testing Workflow" section

🤖 Generated with [Claude Code](https://claude.com/claude-code)