### PR TITLE
security: Pin GitHub Actions to full SHA for supply chain security

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -25,7 +25,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6
         with:
           # Checkout the PR head to review actual PR code (not base branch)
           ref: ${{ github.event.pull_request.head.sha }}
@@ -34,7 +34,7 @@ jobs:
 
       - name: Run Claude Code Review
         id: claude-review
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@cc28cf34ba37e7abe223f1198e98333275a7139d # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           # Explicit github_token required for pull_request_target (OIDC doesn't work)

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -38,13 +38,13 @@ jobs:
       actions: read # Required by claude-code-action to access workflow run data
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6
         with:
           fetch-depth: 1
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@cc28cf34ba37e7abe223f1198e98333275a7139d # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 

--- a/.github/workflows/greet.yml
+++ b/.github/workflows/greet.yml
@@ -13,7 +13,7 @@ jobs:
       issues: write
       pull-requests: write
     steps:
-      - uses: actions/first-interaction@v3
+      - uses: actions/first-interaction@1c4688942c71f71d4f5502a26ea67c331730fa4d # v3
         with:
           issue_message: |
             👋 Thanks for opening your first issue! We appreciate your contribution to requirements-expert.

--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -14,10 +14,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6
 
       - name: Link Checker
-        uses: lycheeverse/lychee-action@v2
+        uses: lycheeverse/lychee-action@a8c4c7cb88f0c7386610c35eb25108e448569cb0 # v2
         with:
           args: --verbose --no-progress --exclude-link-local --exclude-file .lycheeignore '**/*.md'
           fail: true
@@ -26,7 +26,7 @@ jobs:
 
       - name: Create Issue From File
         if: failure()
-        uses: peter-evans/create-issue-from-file@v6
+        uses: peter-evans/create-issue-from-file@fca9117c27cdc29c6c4db3b86c48e4115a786710 # v6
         with:
           title: Broken links detected
           content-filepath: ./lychee/out.md

--- a/.github/workflows/markdownlint.yml
+++ b/.github/workflows/markdownlint.yml
@@ -16,10 +16,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6
 
       - name: Run markdownlint
-        uses: articulate/actions-markdownlint@v1
+        uses: articulate/actions-markdownlint@ab2cefb7bda6ac43ba087d46988b36e18bd57bfd # v1
         with:
           config: .markdownlint.json
           files: "**/*.md"

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -13,7 +13,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v10
+      - uses: actions/stale@5f858e3efba33a5ca4407a664cc011ad407f2008 # v10
         with:
           stale-issue-message: 'This issue has been automatically marked as stale because it has not had recent activity. It will be closed if no further activity occurs. Thank you for your contributions.'
           stale-pr-message: 'This PR has been automatically marked as stale because it has not had recent activity. It will be closed if no further activity occurs.'

--- a/.github/workflows/validate-workflows.yml
+++ b/.github/workflows/validate-workflows.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6
 
       - name: Download actionlint
         id: get_actionlint


### PR DESCRIPTION
## Summary
- Pin all GitHub Actions to full 40-character commit SHA instead of mutable version tags
- Add version comments next to each SHA for maintainability
- Prevents supply chain attacks where attackers could modify tags to point to malicious code

## Actions Pinned

| Action | SHA | Version |
|--------|-----|---------|
| `actions/checkout` | `1af3b93b6815bc44a9784bd300feb67ff0d1eeb3` | v6 |
| `articulate/actions-markdownlint` | `ab2cefb7bda6ac43ba087d46988b36e18bd57bfd` | v1 |
| `lycheeverse/lychee-action` | `a8c4c7cb88f0c7386610c35eb25108e448569cb0` | v2 |
| `peter-evans/create-issue-from-file` | `fca9117c27cdc29c6c4db3b86c48e4115a786710` | v6 |
| `actions/first-interaction` | `1c4688942c71f71d4f5502a26ea67c331730fa4d` | v3 |
| `actions/stale` | `5f858e3efba33a5ca4407a664cc011ad407f2008` | v10 |
| `anthropics/claude-code-action` | `cc28cf34ba37e7abe223f1198e98333275a7139d` | v1 |

## Files Changed
- `.github/workflows/markdownlint.yml`
- `.github/workflows/links.yml`
- `.github/workflows/validate-workflows.yml`
- `.github/workflows/greet.yml`
- `.github/workflows/stale.yml`
- `.github/workflows/claude.yml`
- `.github/workflows/claude-code-review.yml`

## Test plan
- [ ] All workflows pass CI validation
- [ ] Dependabot can still update pinned SHAs when new versions are released

Closes #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)