### PR TITLE
ci: Add concurrency controls to all GitHub Actions workflows

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -6,6 +6,12 @@ on:
   pull_request_target:
     types: [opened, synchronize]
 
+# Cancel in-progress reviews when new commits are pushed to the same PR
+# This prevents duplicate reviews on rapid pushes and saves API tokens
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   claude-review:
     # Only allow trusted authors (OWNER, MEMBER, COLLABORATOR) to trigger reviews

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -10,6 +10,11 @@ on:
   pull_request_review:
     types: [submitted]
 
+# Group by issue/PR number to prevent overlapping runs for same item
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.issue.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   claude:
     # Only allow repo collaborators (OWNER, MEMBER, COLLABORATOR) to trigger @claude

--- a/.github/workflows/greet.yml
+++ b/.github/workflows/greet.yml
@@ -6,6 +6,12 @@ on:
   issues:
     types: [opened]
 
+# Group by PR/issue number to prevent overlapping greetings for same item
+# cancel-in-progress: false ensures all first-timers get greeted
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.issue.number || github.ref }}
+  cancel-in-progress: false
+
 jobs:
   greeting:
     runs-on: ubuntu-latest

--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -8,6 +8,10 @@ on:
     - cron: '0 0 * * 0'  # Weekly on Sunday at midnight UTC
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   linkChecker:
     name: Check Markdown Links

--- a/.github/workflows/markdownlint.yml
+++ b/.github/workflows/markdownlint.yml
@@ -10,6 +10,10 @@ on:
     paths:
       - "**.md"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   lint:
     name: Lint Markdown Files

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -5,6 +5,10 @@ on:
     - cron: '0 0 * * *'  # Daily at midnight UTC
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   issues: write
   pull-requests: write

--- a/.github/workflows/validate-workflows.yml
+++ b/.github/workflows/validate-workflows.yml
@@ -6,6 +6,10 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   actionlint:
     name: Lint GitHub Actions Workflows


### PR DESCRIPTION
## Summary

- Add concurrency controls to all 7 GitHub Actions workflows to prevent wasteful overlapping runs
- Group runs by workflow name and branch/PR to cancel superseded runs
- Use smart grouping for `pull_request_target` events (PR/issue number instead of ref)
- Set `cancel-in-progress: false` for greet.yml to ensure first-timers always get greeted

## Changes by Workflow

| Workflow | Concurrency Group | Cancel In-Progress | Notes |
|----------|------------------|-------------------|-------|
| markdownlint.yml | workflow-ref | ✅ true | Standard grouping |
| links.yml | workflow-ref | ✅ true | Standard grouping |
| validate-workflows.yml | workflow-ref | ✅ true | Standard grouping |
| stale.yml | workflow-ref | ✅ true | Scheduled workflow protection |
| greet.yml | workflow-PR/issue | ❌ false | Ensures all first-timers greeted |
| claude.yml | workflow-PR/issue | ✅ true | Handles multiple event types |
| claude-code-review.yml | workflow-PR | ✅ true | **HIGH PRIORITY** - Prevents duplicate reviews |

## Benefits

1. **Resource efficiency** - No wasted compute on superseded runs
2. **Faster feedback** - Latest code gets checked first
3. **Cleaner PR checks** - No confusing multiple pending checks
4. **Cost savings** - Fewer GitHub Actions minutes consumed
5. **API token efficiency** - Prevents duplicate Claude API calls on rapid pushes

## Test Plan

- [x] All workflows have concurrency block
- [x] Concurrency groups use appropriate identifiers for event types
- [x] `cancel-in-progress` set appropriately per workflow
- [ ] CI passes after merge
- [ ] Verify behavior: new push cancels in-progress run (manual verification)

Closes #42

🤖 Generated with [Claude Code](https://claude.com/claude-code)