### PR TITLE
ci: Add PR auto-labeler based on changed files

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,39 @@
+# Configuration for actions/labeler
+# Automatically applies labels to PRs based on changed files
+# See: https://github.com/actions/labeler
+
+# Component labels
+"component:command":
+  - changed-files:
+      - any-glob-to-any-file: "plugins/requirements-expert/commands/**/*"
+
+"component:skill":
+  - changed-files:
+      - any-glob-to-any-file: "plugins/requirements-expert/skills/**/*"
+
+"component:agent":
+  - changed-files:
+      - any-glob-to-any-file: "plugins/requirements-expert/agents/**/*"
+
+"component:hook":
+  - changed-files:
+      - any-glob-to-any-file: "plugins/requirements-expert/hooks/**/*"
+
+# Documentation label - markdown files except those in component directories
+"component:docs":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "**/*.md"
+          - "!plugins/requirements-expert/commands/**/*.md"
+          - "!plugins/requirements-expert/skills/**/*.md"
+          - "!plugins/requirements-expert/agents/**/*.md"
+
+# GitHub Actions workflows
+"github-actions":
+  - changed-files:
+      - any-glob-to-any-file: ".github/workflows/**/*"
+
+# Dependencies (Dependabot config)
+"dependencies":
+  - changed-files:
+      - any-glob-to-any-file: ".github/dependabot.yml"

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,28 @@
+name: PR Labeler
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+
+# Using pull_request_target is safe here because we only read file paths,
+# not execute any code from the PR
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  label:
+    name: Apply Labels Based on Changed Files
+    runs-on: ubuntu-latest
+    steps:
+      - name: Apply labels
+        uses: actions/labeler@8558fd74291d67161a8a78ce36a881fa63b766a9 # v5
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          configuration-path: .github/labeler.yml
+          sync-labels: true


### PR DESCRIPTION
## Summary

- Add `.github/labeler.yml` configuration for automatic PR labeling
- Add `.github/workflows/labeler.yml` workflow using actions/labeler@v5
- Labels applied based on changed files matching component paths

## Label Mappings

| File Path Pattern | Label Applied |
|-------------------|---------------|
| `plugins/.../commands/**` | `component:command` |
| `plugins/.../skills/**` | `component:skill` |
| `plugins/.../agents/**` | `component:agent` |
| `plugins/.../hooks/**` | `component:hook` |
| `**/*.md` (except components) | `component:docs` |
| `.github/workflows/**` | `github-actions` |
| `.github/dependabot.yml` | `dependencies` |

## Security Notes

- Action pinned to full SHA (`8558fd74291d67161a8a78ce36a881fa63b766a9`) for supply chain security
- Uses `pull_request_target` which is safe because we only read file paths, not execute PR code
- `sync-labels: true` ensures labels update when files change

## Test plan

- [ ] Verify workflow triggers on this PR
- [ ] Verify `github-actions` label is auto-applied (this PR modifies `.github/workflows/`)
- [ ] Create test PR touching multiple components to verify multi-label application

Closes #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)