### PR TITLE
fix: Trigger release drafter only on tag push

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -2,9 +2,8 @@ name: Release Drafter
 
 on:
   push:
-    branches: [main]
-  pull_request_target:
-    types: [opened, reopened, synchronize]
+    tags:
+      - 'v*'
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary

Change Release Drafter to only run when version tags are pushed, not on every PR/push to main.

## Changes

- Trigger: `push: tags: ['v*']` instead of `push: branches: [main]` + `pull_request_target`

## Behavior Change

**Before**: Draft release updated on every PR merge to main
**After**: Draft release created/updated only when a version tag (e.g., `v0.2.0`) is pushed

🤖 Generated with [Claude Code](https://claude.com/claude-code)