### PR TITLE
fix: Remove inner quotes from claude_args to fix shell quoting issue

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -64,4 +64,4 @@ jobs:
           # or https://docs.claude.com/en/docs/claude-code/cli-reference for available options
           # Note: Using gh pr comment because use_sticky_comment only works with pull_request events,
           # not pull_request_target. Comments will appear from github-actions[bot].
-          claude_args: '--allowed-tools "Read,Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"'
+          claude_args: '--allowed-tools Read,Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)'


### PR DESCRIPTION
## Summary

Fixes shell quoting issue in Claude Code Review workflow that was preventing proper tool recognition.

## Problem

The inner double quotes in `claude_args` were being stripped by shell expansion:

```yaml
# Before (quotes get stripped):
claude_args: '--allowed-tools "Read,Bash(gh pr comment:*)..."'

# After (no quotes to strip):
claude_args: '--allowed-tools Read,Bash(gh pr comment:*)...'
```

## Solution

Remove the inner double quotes. Since the comma-separated tool list has no spaces, quotes aren't needed. YAML single quotes preserve the literal content, and with no inner quotes, there's nothing for shell expansion to strip.

## Test Plan

- [ ] Merge this PR and observe that Claude Code Review runs
- [ ] Verify Claude posts a review comment on the next PR

Closes #73

🤖 Generated with [Claude Code](https://claude.com/claude-code)