### PR TITLE
fix: Reduce duplicate content in epic-identification skill templates

### DIFF
--- a/plugins/requirements-expert/skills/epic-identification/SKILL.md
+++ b/plugins/requirements-expert/skills/epic-identification/SKILL.md
@@ -115,14 +115,24 @@ Create clear, descriptive titles and summaries:
 - "Make users happy" (outcome, not capability)
 - "Phase 1" (not descriptive)
 
-**Epic Description Structure:**
+### Epic Issue Template (Minimal)
 
-Use the template from `${CLAUDE_PLUGIN_ROOT}/skills/epic-identification/references/epic-template.md`:
-1. **Overview** - What this epic delivers
-2. **User Value** - Why this matters to users
-3. **Scope** - What's included and excluded
-4. **Success Criteria** - How we know it's done
-5. **Dependencies** - Other epics or external factors required
+```markdown
+## Epic Overview
+[Brief description]
+
+## Value Proposition
+[Why this matters]
+
+## Scope
+- Included: [capabilities]
+- Excluded: [out of scope]
+
+## Success Criteria
+- [ ] [Measurable outcomes]
+```
+
+See `references/epic-template.md` for comprehensive templates and domain-specific examples.
 
 ### Step 5: Validate Completeness
 


### PR DESCRIPTION
## Description

Replace the descriptive numbered list in the epic-identification SKILL.md with a minimal copyable markdown template. The full comprehensive template remains in `references/epic-template.md` for detailed guidance.

**Before:** A 5-item numbered list describing template sections
**After:** A minimal copyable markdown template in a fenced code block with a pointer to the full reference

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to README, CLAUDE.md, or component docs)
- [x] Refactoring (code change that neither fixes a bug nor adds a feature)
- [ ] Configuration change (changes to .markdownlint.json, plugin.json, etc.)

## Component(s) Affected

- [ ] Commands (`/re:*`)
- [x] Skills (methodology and best practices)
- [ ] Agents (requirements-assistant, requirements-validator)
- [ ] Hooks (UserPromptSubmit)
- [ ] Documentation (README.md, CLAUDE.md, SECURITY.md)
- [ ] Configuration (.markdownlint.json, plugin.json, marketplace.json)
- [ ] Issue/PR templates
- [ ] Other (please specify):

## Motivation and Context

This change follows the progressive disclosure principle and CLAUDE.md guidance: "Never duplicate content between SKILL.md and references/". The minimal template provides a quick copy-paste reference while directing users to the comprehensive template for full details.

Fixes #78

## How Has This Been Tested?

**Test Configuration**:
- Claude Code version: Claude Opus 4.5
- GitHub CLI version: 2.x
- OS: macOS 15.5 (Darwin 25.1.0)

**Test Steps**:
1. Verified markdown linting passes: `markdownlint plugins/requirements-expert/skills/epic-identification/SKILL.md`
2. Verified the minimal template is copyable and properly formatted
3. Verified the reference pointer uses the correct filename (`epic-template.md`)

## Checklist

### General

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas (if applicable)
- [x] My changes generate no new warnings or errors

### Documentation

- [x] I have updated the documentation accordingly (README.md, CLAUDE.md, or component docs)
- [x] I have updated YAML frontmatter (if applicable)
- [x] I have verified all links work correctly

### Markdown

- [x] I have run `markdownlint` and fixed all issues
- [x] My markdown follows the repository style (ATX headers, dash lists, fenced code blocks)
- [x] I have verified special HTML elements are properly closed (`<example>`, `<commentary>`, etc.)

### Component-Specific Checks

#### Skills (if applicable)

- [x] Description uses third-person with specific trigger phrases
- [x] SKILL.md is under 2,000 words (progressive disclosure)
- [x] Detailed content is in `references/` subdirectory
- [x] Templates follow the established format

### Testing

- [x] I have tested the plugin locally with `cc --plugin-dir plugins/requirements-expert`
- [ ] I have tested the full workflow (if applicable)
- [ ] I have verified GitHub CLI integration works (if applicable)
- [ ] I have tested in a clean repository (not my development repo)

### Version Management (if applicable)

- [ ] I have updated version numbers in both `plugin.json` and `marketplace.json` (if this is a release)
- [ ] I have updated the changelog in README.md (if this is a release)

## Additional Notes

Note: The issue referenced `epic-templates.md` (plural) but the actual file is `epic-template.md` (singular). The PR uses the correct singular filename.

## Reviewer Notes

**Areas that need special attention**:
- Verify the minimal template captures the essential structure users need for quick reference

**Known limitations or trade-offs**:
- The minimal template omits Dependencies section (available in full template)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)