### PR TITLE
docs: Remove duplicate content from epic-identification SKILL.md

### DIFF
--- a/plugins/requirements-expert/skills/epic-identification/SKILL.md
+++ b/plugins/requirements-expert/skills/epic-identification/SKILL.md
@@ -219,53 +219,7 @@ All user stories for this epic will be created as child issues, establishing hie
 
 ## Epic Templates and Patterns
 
-### Common Epic Patterns
-
-**User-Facing Capabilities:**
-- User Onboarding & Registration
-- Profile & Settings Management
-- Core Workflow/Activity (varies by product)
-- Search & Discovery
-- Notifications & Alerts
-
-**Data & Content:**
-- Data Import/Export
-- Content Creation & Editing
-- Content Organization (tags, folders, etc.)
-- Data Visualization & Reporting
-
-**Collaboration & Sharing:**
-- Team/Organization Management
-- Permissions & Access Control
-- Sharing & Collaboration Features
-- Activity Feeds & History
-
-**Integration & APIs:**
-- Third-party Integrations
-- Public API
-- Webhooks & Event Streaming
-
-**Infrastructure/Technical:**
-- Authentication & Authorization
-- Performance & Scalability
-- Data Migration
-- Offline Support
-
-### Example: E-commerce Product
-
-**Vision:** "Enable small businesses to sell products online easily"
-
-**Identified Epics:**
-1. Product Catalog Management
-2. Shopping Cart & Checkout
-3. Payment Processing Integration
-4. Order Management & Fulfillment
-5. Customer Account Management
-6. Admin Dashboard & Analytics
-7. Marketing & Promotions
-8. Email Notifications
-
-Each maps to a major capability needed to deliver the vision.
+For common epic patterns (universal and domain-specific) and working examples, consult `references/common-patterns.md`.
 
 ## Best Practices
 


### PR DESCRIPTION
## Description

Replace the "Epic Templates and Patterns" section in `SKILL.md` (~150 words of duplicate content) with a brief pointer to `references/common-patterns.md`.

This follows the progressive disclosure principle: detailed content belongs in reference files, not duplicated in the main SKILL.md.

## Type of Change

- [x] Documentation update (improvements to README, CLAUDE.md, or component docs)

## Component(s) Affected

- [x] Skills (methodology and best practices)

## Motivation and Context

The "Epic Templates and Patterns" section duplicated content already present in `references/common-patterns.md`:
- Common epic pattern categories (User-Facing, Data & Content, Collaboration, etc.)
- E-commerce example with 8 epics

This violates the skill development best practice:
> "Information should live in either SKILL.md or references files, not both."

Fixes #90

## How Has This Been Tested?

**Test Configuration**:
- Claude Code version: Latest
- GitHub CLI version: 2.x
- OS: macOS

**Test Steps**:
1. Verified markdownlint passes on modified file
2. Verified word count decreased from ~1,952 to ~1,802 (within 1,500-2,000 target)
3. Verified reference pointer is clear and actionable

## Checklist

### General

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas (if applicable)
- [x] My changes generate no new warnings or errors

### Documentation

- [x] I have updated the documentation accordingly (README.md, CLAUDE.md, or component docs)
- [x] I have updated YAML frontmatter (if applicable)
- [x] I have verified all links work correctly

### Markdown

- [x] I have run `markdownlint` and fixed all issues
- [x] My markdown follows the repository style (ATX headers, dash lists, fenced code blocks)
- [x] I have verified special HTML elements are properly closed (`<example>`, `<commentary>`, etc.)

### Component-Specific Checks

#### Skills (if applicable)

- [x] Description uses third-person with specific trigger phrases
- [x] SKILL.md is under 2,000 words (progressive disclosure)
- [x] Detailed content is in `references/` subdirectory
- [x] Templates follow the established format

## Additional Notes

**Before**: ~1,952 words, duplicate content in both SKILL.md and references/common-patterns.md
**After**: ~1,802 words, single source of truth in references/common-patterns.md

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)