### PR TITLE
docs: Consolidate redundant reference sections in epic-identification SKILL.md

### DIFF
--- a/plugins/requirements-expert/skills/epic-identification/SKILL.md
+++ b/plugins/requirements-expert/skills/epic-identification/SKILL.md
@@ -324,23 +324,15 @@ Don't forget necessary enablers:
 8. **Create Issues** → Add to GitHub Projects as children of vision
 9. **Proceed** → Move to user story creation for each epic
 
-## When to Use References
+## Reference Files
 
 Load references based on context:
 
-- **`references/discovery-techniques.md`**: When applying multiple discovery methods or user needs technique guidance
-- **`references/epic-template.md`**: When creating epic issue content or user requests templates
-- **`references/common-patterns.md`**: When user's domain is identified for pattern suggestions
-
-## Additional Resources
-
-### Reference Files
-
-For detailed epic templates and examples:
-
-- **`${CLAUDE_PLUGIN_ROOT}/skills/epic-identification/references/epic-template.md`** - Complete epic definition template
-- **`${CLAUDE_PLUGIN_ROOT}/skills/epic-identification/references/discovery-techniques.md`** - Six techniques for identifying epics
-- **`${CLAUDE_PLUGIN_ROOT}/skills/epic-identification/references/common-patterns.md`** - Universal and domain-specific epic patterns
+| Reference | When to Load | Path |
+|-----------|--------------|------|
+| **discovery-techniques.md** | Applying multiple discovery methods or user needs technique guidance | `references/discovery-techniques.md` |
+| **epic-template.md** | Creating epic issue content or user requests templates | `references/epic-template.md` |
+| **common-patterns.md** | User's domain is identified for pattern suggestions | `references/common-patterns.md` |
 
 ## Next Steps
 


### PR DESCRIPTION
## Summary

Consolidates two overlapping reference sections ("When to Use References" and "Additional Resources") into a single "Reference Files" section using a table format for clearer, more scannable guidance.

## Problem

The SKILL.md file had two separate sections serving the same purpose of pointing to reference files:

1. "When to Use References" (lines 327-333) - contextual triggers with relative paths
2. "Additional Resources" (lines 335-343) - file paths with `${CLAUDE_PLUGIN_ROOT}` prefix

This created redundancy and potential confusion.

Fixes #91 (includes path standardization from merged #89)

## Solution

Merged both sections into a single "Reference Files" table that includes:
- Reference file name
- When to load (contextual trigger)
- Relative path

**Before (two sections, 17 lines):**
```markdown
## When to Use References
- **`references/discovery-techniques.md`**: When applying...

## Additional Resources
### Reference Files
- **`${CLAUDE_PLUGIN_ROOT}/skills/.../discovery-techniques.md`** - Six techniques...
```

**After (one table, 8 lines):**
```markdown
## Reference Files
| Reference | When to Load | Path |
|-----------|--------------|------|
| **discovery-techniques.md** | Applying multiple discovery methods... | `references/discovery-techniques.md` |
```

## Changes

- `plugins/requirements-expert/skills/epic-identification/SKILL.md`:
  - Removed "When to Use References" section
  - Removed "Additional Resources" section
  - Added consolidated "Reference Files" section with table format
  - Standardized on relative paths (not `${CLAUDE_PLUGIN_ROOT}`)

## Testing

- [x] Markdown linting passes
- [x] File structure is correct
- [x] Table renders properly

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Changes are focused and minimal

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)