### PR TITLE
docs(skill): replace ${CLAUDE_PLUGIN_ROOT} with relative paths

### DIFF
--- a/plugins/requirements-expert/skills/vision-discovery/SKILL.md
+++ b/plugins/requirements-expert/skills/vision-discovery/SKILL.md
@@ -83,7 +83,7 @@ Define how success will be measured:
 
 ### Step 5: Document the Vision
 
-Create a structured vision document in GitHub Projects as an issue with Type: Vision. Use the template structure from `${CLAUDE_PLUGIN_ROOT}/skills/vision-discovery/references/vision-template.md`.
+Create a structured vision document in GitHub Projects as an issue with Type: Vision. Use the template structure from `references/vision-template.md`.
 
 **Core Sections:**
 1. **Problem Statement** - What problem exists and why it matters
@@ -189,7 +189,7 @@ All epics will be created as child issues of this vision issue, establishing cle
 ### Reference Files
 
 For detailed vision templates and examples:
-- **`${CLAUDE_PLUGIN_ROOT}/skills/vision-discovery/references/vision-template.md`** - Complete vision template with all sections and guidance
+- **`references/vision-template.md`** - Complete vision template with all sections and guidance
 
 ## Next Steps
 


### PR DESCRIPTION
## Summary

Replace `${CLAUDE_PLUGIN_ROOT}/skills/vision-discovery/` path prefix with relative paths in the vision-discovery skill, matching the pattern used by other skills.

## Problem

The vision-discovery skill uses `${CLAUDE_PLUGIN_ROOT}` variable paths while other skills (like epic-identification) use relative paths. This inconsistency should be fixed for consistency across the plugin.

Fixes #112

## Solution

Replace the two occurrences of the absolute path with relative paths:

| Location | Before | After |
|----------|--------|-------|
| Line 86 | `${CLAUDE_PLUGIN_ROOT}/skills/vision-discovery/references/vision-template.md` | `references/vision-template.md` |
| Line 192 | Same | Same |

This matches the pattern used in epic-identification skill:
```markdown
See `references/epic-template.md` for comprehensive templates...
```

## Changes

- `plugins/requirements-expert/skills/vision-discovery/SKILL.md`: Updated 2 path references to use relative paths

## Testing

- [x] Linting passes (`markdownlint` clean)
- [x] Change is focused and minimal

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Changes are focused and minimal

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)