### PR TITLE
docs(skill): fix second-person violation in vision-discovery

### DIFF
--- a/plugins/requirements-expert/skills/vision-discovery/SKILL.md
+++ b/plugins/requirements-expert/skills/vision-discovery/SKILL.md
@@ -129,7 +129,7 @@ Before finalizing the vision:
 ### Iterate and Refine
 
 Vision is not set in stone:
-- Expect to refine as you learn more
+- Refine as new information emerges
 - Update when market conditions or user needs change
 - Use feedback from epic and story creation to improve clarity
 - Treat vision as a living document


### PR DESCRIPTION
## Summary

Fix second-person ("you") violation in vision-discovery skill by changing to imperative form per Claude Code plugin skill best practices.

## Problem

Line 132 in `plugins/requirements-expert/skills/vision-discovery/SKILL.md` contained:
```markdown
- Expect to refine as you learn more
```

This violates the writing style requirements for Claude Code plugin skills which mandate imperative/infinitive form, not second person.

Fixes #110

## Solution

Changed to imperative form:
```markdown
- Refine as new information emerges
```

This matches the pattern of adjacent bullets ("Update...", "Use...", "Treat...") and follows verb-first instructions.

## Changes

- `plugins/requirements-expert/skills/vision-discovery/SKILL.md`: Line 132 - Changed "Expect to refine as you learn more" to "Refine as new information emerges"

## Testing

- [x] Markdownlint passes
- [x] Verified no other "you" violations in instructional content (existing "you" on line 39 is in questions to users, not instructions)

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Changes are focused and minimal

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)