### PR TITLE
docs(skill): fix misleading templates reference in vision-discovery

### DIFF
--- a/plugins/requirements-expert/skills/vision-discovery/SKILL.md
+++ b/plugins/requirements-expert/skills/vision-discovery/SKILL.md
@@ -184,12 +184,13 @@ All epics will be created as child issues of this vision issue, establishing cle
 6. **Validate** → Review with stakeholders and refine
 7. **Proceed** → Move to epic identification once vision is solid
 
-## Additional Resources
+## Reference Files
 
-### Reference Files
+For detailed vision templates:
 
-For detailed vision templates and examples:
-- **`references/vision-template.md`** - Complete vision template with all sections and guidance
+| Reference | When to Load | Path |
+|-----------|--------------|------|
+| **vision-template.md** | Creating vision issue content or documenting vision | `references/vision-template.md` |
 
 ## Next Steps
 


### PR DESCRIPTION
## Description

Fix misleading text in the Additional Resources section of vision-discovery SKILL.md. The section claimed to provide "templates and examples" but only contained a template reference - no examples exist.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update (improvements to README, CLAUDE.md, or component docs)
- [ ] Refactoring (code change that neither fixes a bug nor adds a feature)
- [ ] Configuration change (changes to .markdownlint.json, plugin.json, etc.)

## Component(s) Affected

- [ ] Commands (`/re:*`)
- [x] Skills (methodology and best practices)
- [ ] Agents (requirements-assistant, requirements-validator)
- [ ] Hooks (UserPromptSubmit)
- [ ] Documentation (README.md, CLAUDE.md, SECURITY.md)
- [ ] Configuration (.markdownlint.json, plugin.json, marketplace.json)
- [ ] Issue/PR templates
- [ ] Other (please specify):

## Motivation and Context

The vision-discovery skill's "Additional Resources" section stated "For detailed vision templates and examples:" but only referenced a single template file. No examples directory or example files exist. This is an accuracy issue that could confuse users looking for examples.

Fixes #111

## Changes Made

1. Renamed section from "Additional Resources" with "Reference Files" subheading to just "## Reference Files"
2. Changed "templates and examples" to "templates" (accurate to what exists)
3. Reformatted as table for consistency with other skills' reference documentation

## How Has This Been Tested?

**Test Configuration**:
- GitHub CLI version: 2.x
- OS: macOS
- markdownlint: ✅ Passes

**Test Steps**:
1. Ran `markdownlint` on the modified file - passes
2. Verified only `references/vision-template.md` exists (no examples directory)

## Checklist

### General

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings or errors

### Documentation

- [x] I have updated the documentation accordingly
- [x] I have verified all links work correctly

### Markdown

- [x] I have run `markdownlint` and fixed all issues
- [x] My markdown follows the repository style (ATX headers, dash lists, fenced code blocks)

### Component-Specific Checks

#### Skills

- [x] Description uses third-person with specific trigger phrases
- [x] SKILL.md is under 2,000 words (progressive disclosure)
- [x] Detailed content is in `references/` subdirectory

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)