### PR TITLE
docs(skill): add two-layer metadata system to vision-discovery

### DIFF
--- a/plugins/requirements-expert/skills/vision-discovery/SKILL.md
+++ b/plugins/requirements-expert/skills/vision-discovery/SKILL.md
@@ -142,13 +142,17 @@ Create the vision as a GitHub issue in the relevant GitHub Project:
 
 **Issue Description:** Full vision document with all sections
 
-**Custom Fields:**
-- Type: Vision
-- Status: Active
-- Priority: (Not applicable for vision)
+**Two-Layer Metadata (both required):**
 
-**Labels:**
-- `type:vision`
+Set BOTH custom fields AND labels to ensure proper filtering:
+
+| Layer | Field | Value | Purpose |
+|-------|-------|-------|---------|
+| Custom Field | Type | Vision | Project views and filtering |
+| Custom Field | Status | Active | Project status tracking |
+| Label | `type:vision` | - | Cross-project queries, API filtering |
+
+**Why both?** Custom fields are project-specific and enable GitHub Projects views and filtering. Labels are portable across GitHub and enable API-based filtering and cross-project queries.
 
 All epics will be created as child issues of this vision issue, establishing clear traceability.
 


### PR DESCRIPTION
## Summary

Add documentation for the two-layer metadata system to the vision-discovery skill, explaining why both custom fields and labels are required for GitHub Projects integration.

## Problem

The vision-discovery skill documented custom fields and labels separately but didn't explain the architectural pattern or why both are required.

Fixes #113

## Solution

Replaced the separate "Custom Fields" and "Labels" sections with a consolidated "Two-Layer Metadata" section that:

- Uses a table format showing Layer, Field, Value, and Purpose
- Explains that BOTH are required
- Documents why: custom fields enable Project views/filtering, labels enable cross-project queries and API filtering

## Changes

- `plugins/requirements-expert/skills/vision-discovery/SKILL.md`: Updated "Integration with GitHub Projects" section (lines 145-155)

## Testing

- [x] Markdown linting passes
- [x] Content aligns with CLAUDE.md architecture documentation
- [x] Table format renders correctly

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Changes are focused and minimal
- [x] Documentation updated

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)