### PR TITLE
docs(skill): clarify when to include optional vision sections

### DIFF
--- a/plugins/requirements-expert/skills/vision-discovery/SKILL.md
+++ b/plugins/requirements-expert/skills/vision-discovery/SKILL.md
@@ -140,7 +140,12 @@ Create a structured vision document in GitHub Projects as an issue with Type: Vi
 **Additional Sections (as applicable):**
 
 7. **Strategic Alignment** - Business goals, market opportunity, competitive landscape
+   - _Include when_: Vision supports broader organizational strategy, multiple stakeholders need market positioning context, or competitive differentiation is a key concern
+   - _Skip when_: Internal tools, personal projects, or when strategic context is obvious from problem statement
+
 8. **Risks & Assumptions** - Key assumptions that must hold true, known risks and mitigations
+   - _Include when_: Product has significant dependencies or unknowns, major assumptions underpin viability, or stakeholders need visibility into potential blockers
+   - _Skip when_: Low-risk well-understood domains, small-scope projects, or when risks are negligible
 
 **Examples:**
 - ✅ Create vision issue with all 6 core sections, Type=Vision custom field, and `type:vision` label


### PR DESCRIPTION
## Summary

Add guidance for when to include or skip the optional "Strategic Alignment" and "Risks & Assumptions" sections in vision documents.

## Problem

The vision-discovery skill lists "Additional Sections (as applicable)" but doesn't explain WHEN these sections are applicable vs when they can be skipped. This leaves Claude without clear guidance to decide whether to include or omit these sections based on context.

Fixes #127

## Solution

Added "Include when" and "Skip when" guidance inline with each optional section, providing concrete scenarios for when each section adds value vs when it can be omitted.

### Changes

- Added _Include when_ and _Skip when_ guidance for Strategic Alignment section
- Added _Include when_ and _Skip when_ guidance for Risks & Assumptions section

## Testing

- [x] Markdownlint passes
- [x] Changes are focused and minimal

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)