### PR TITLE
feat(skill): expand trigger phrases in user-story-creation

### DIFF
--- a/plugins/requirements-expert/skills/user-story-creation/SKILL.md
+++ b/plugins/requirements-expert/skills/user-story-creation/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: User Story Creation
-description: This skill should be used when the user asks to "create user stories", "write user stories", "break down epic into stories", "define user stories", "what stories do I need", or when they have epics defined and need to decompose them into specific, valuable user stories following INVEST criteria.
+description: This skill should be used when the user asks to "create user stories", "write user stories", "break down epic into stories", "define user stories", "what stories do I need", "apply INVEST criteria", "write acceptance criteria", "split a large story", "story is too big", "story splitting", or when decomposing epics into specific, valuable user stories.
 version: 0.2.0
 ---
 


### PR DESCRIPTION
## Summary

Expands the trigger phrases in the user-story-creation skill description to improve discoverability when users ask about related topics.

## Problem

The skill description missed common phrases users might say when they need help with INVEST criteria, acceptance criteria, or story splitting—all topics covered by the skill content.

Fixes #132

## Solution

Added five additional trigger phrases to the frontmatter description:
- "apply INVEST criteria"
- "write acceptance criteria"
- "split a large story"
- "story is too big"
- "story splitting"

These phrases map directly to existing skill content:
- INVEST criteria: lines 88-101, 147-154
- Acceptance criteria: lines 157-183
- Story splitting: lines 213-228

### Alternatives Considered

- Keep current triggers only: Works but misses legitimate use cases
- Add more phrases: The five chosen are high-value without bloating the description

## Changes

- `plugins/requirements-expert/skills/user-story-creation/SKILL.md`: Updated description field with new trigger phrases

## Testing

- [x] Linting passes (`markdownlint`)
- [x] Trigger phrases match existing skill content

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Changes are focused and minimal

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)