### PR TITLE
docs(skill): remove redundant 'When to Use' section in user-story-creation

### DIFF
--- a/plugins/requirements-expert/skills/user-story-creation/SKILL.md
+++ b/plugins/requirements-expert/skills/user-story-creation/SKILL.md
@@ -26,17 +26,9 @@ Well-written user stories:
 - Enable detailed estimation and planning
 - Facilitate conversation and refinement
 
-## When to Use This Skill
+## Prerequisite
 
-Use user story creation when:
-
-- An epic exists and needs to be broken into stories
-- User asks for detailed requirements for a capability
-- Planning an iteration and need to define work
-- Refining or adding stories to an existing epic
-- Validating that stories cover the full epic scope
-
-**Prerequisite:** Epic must exist before creating stories. If no epic exists, use epic-identification skill first.
+Epic must exist before creating stories. If no epic exists, use epic-identification skill first.
 
 ## User Story Format
 


### PR DESCRIPTION
## Summary

Removes redundant "When to Use This Skill" section from user-story-creation SKILL.md, consolidating to a single prerequisite note.

## Problem

The "When to Use This Skill" section (lines 27-36) duplicated information already in the frontmatter description:

- Frontmatter: `"when the user asks to 'create user stories'... or when they have epics defined"`
- Section: `"Use user story creation when: An epic exists and needs to be broken into stories..."`

This redundancy:
1. Wastes context window when skill loads
2. Creates maintenance burden (two places to update)
3. Violates DRY principle

Fixes #133

## Solution

Adopted **Option 2** from the issue: consolidate to a single prerequisite note.

The section was replaced with:
```markdown
## Prerequisite

Epic must exist before creating stories. If no epic exists, use epic-identification skill first.
```

This keeps the essential workflow guidance (prerequisite) that was NOT in the frontmatter, while removing the duplicated trigger conditions.

### Why Option 2 over Option 1

- The prerequisite note provides valuable workflow context
- Frontmatter focuses on trigger phrases, not workflow dependencies
- Users benefit from seeing the prerequisite clearly when the skill loads

## Changes

- `plugins/requirements-expert/skills/user-story-creation/SKILL.md`: Removed 10 lines, added 2 lines

## Testing

- [x] Markdown linting passes (`markdownlint` reports no issues)
- [x] File structure intact
- [x] Prerequisite information preserved

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)