### PR TITLE
fix(ci): wrap allowed-tools in quotes to fix shell-quote parsing

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -183,4 +183,7 @@ jobs:
           # Model selection based on PR complexity analysis
           # Grep added to enable verification of consistency claims
           # gh pr checks added to verify CI status if needed
-          claude_args: '--model ${{ steps.analyze.outputs.model }} --allowed-tools Read,Grep,Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*),Bash(gh pr checks:*)'
+          # IMPORTANT: The allowed-tools value MUST be wrapped in double quotes to prevent
+          # shell-quote from parsing parentheses and asterisks as shell operators.
+          # See: https://github.com/substack/node-shell-quote - parse() treats ( ) * as operators
+          claude_args: '--model ${{ steps.analyze.outputs.model }} --allowed-tools "Read,Grep,Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*),Bash(gh pr checks:*)"'


### PR DESCRIPTION
## Summary

Fixes the Claude Code Review workflow failing to post review comments due to `shell-quote` parsing issues in the `claude-code-action`.

## Problem

The `claude-code-action` uses `shell-quote` to parse `claude_args`. This library interprets special characters as shell operators:

| Character | Interpretation |
|-----------|---------------|
| `(` `)` | Command grouping |
| `*` | Glob pattern |
| `:*` | Glob pattern |

This caused `Bash(gh pr comment:*)` to be parsed as separate tokens and non-string operator objects, which get filtered out, resulting in a mangled command that breaks tool permissions.

**Before (mangled):**
```
--allowed-tools Read,Grep,Bash gh issue ,Bash gh ,Bash gh pr ...
```

**After (correct):**
```
--allowed-tools "Read,Grep,Bash(gh issue view:*),Bash(gh pr comment:*)..."
```

## Solution

Wrap the `--allowed-tools` value in double quotes. Shell-quote preserves quoted strings as literals:

```js
parse('--allowed-tools "Bash(gh pr comment:*)"')
// Returns: ['--allowed-tools', 'Bash(gh pr comment:*)'] ✓
```

## Testing

Verified locally with Node.js:
```js
const { parse } = require('shell-quote');
parse('--allowed-tools "Bash(gh pr comment:*)"')
// ['--allowed-tools', 'Bash(gh pr comment:*)'] ✓
```

## Regression Source

Introduced in #107 when adding `--model ${{ }}` interpolation to the same `claude_args` string.

Fixes #143

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)