### PR TITLE
docs(skill): remove redundant Children section from epic-template

### DIFF
--- a/plugins/requirements-expert/skills/epic-identification/references/epic-template.md
+++ b/plugins/requirements-expert/skills/epic-identification/references/epic-template.md
@@ -161,4 +161,3 @@ At epic level, done means:
 ---
 
 **Parent:** [Link to Vision Issue]
-**Children:** [User Story Issues will be linked here]


### PR DESCRIPTION
## Summary

Remove the redundant "Children" metadata line from epic-template.md since GitHub Projects handles parent/child relationships automatically.

## Problem

The epic-template.md contained a redundant `**Children:** [User Story Issues will be linked here]` line that doesn't serve any purpose because GitHub Projects automatically manages parent/child issue relationships.

Fixes #145

## Solution

Remove line 164 containing the redundant Children metadata, keeping only the `**Parent:**` line for consistency with `story-template.md` and `task-template.md`.

## Changes

- `plugins/requirements-expert/skills/epic-identification/references/epic-template.md`: Remove redundant Children line

## Testing

- [x] Markdownlint passes
- [x] Change is consistent with story-template.md (updated in PR #142)

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Changes are focused and minimal

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)