### PR TITLE
docs(skill): standardize relative paths in skill references

### DIFF
--- a/plugins/requirements-expert/skills/prioritization/SKILL.md
+++ b/plugins/requirements-expert/skills/prioritization/SKILL.md
@@ -403,8 +403,11 @@ Priorities set once and never revisited:
 
 ### Reference Files
 
-For detailed prioritization frameworks and examples:
-- **`${CLAUDE_PLUGIN_ROOT}/skills/prioritization/references/moscow-worksheet.md`** - Template for conducting MoSCoW prioritization sessions
+Load references as needed:
+
+| Reference | When to Load | Path |
+|-----------|--------------|------|
+| **moscow-worksheet.md** | Conducting MoSCoW prioritization sessions or applying prioritization framework | `references/moscow-worksheet.md` |
 
 ## Integration with Requirements Lifecycle
 

--- a/plugins/requirements-expert/skills/requirements-feedback/SKILL.md
+++ b/plugins/requirements-expert/skills/requirements-feedback/SKILL.md
@@ -486,8 +486,11 @@ Echo chamber risk:
 
 ### Reference Files
 
-For feedback templates and frameworks:
-- **`${CLAUDE_PLUGIN_ROOT}/skills/requirements-feedback/references/feedback-checklist.md`** - Checklist for conducting feedback reviews at each level
+Load references as needed:
+
+| Reference | When to Load | Path |
+|-----------|--------------|------|
+| **feedback-checklist.md** | Conducting feedback reviews or validating requirements at any level | `references/feedback-checklist.md` |
 
 ---
 

--- a/plugins/requirements-expert/skills/task-breakdown/SKILL.md
+++ b/plugins/requirements-expert/skills/task-breakdown/SKILL.md
@@ -381,8 +381,11 @@ Full traceability: Vision → Epic → Story → Task
 
 ### Reference Files
 
-For detailed task templates:
-- **`${CLAUDE_PLUGIN_ROOT}/skills/task-breakdown/references/task-template.md`** - Complete task template with acceptance criteria formats
+Load references as needed:
+
+| Reference | When to Load | Path |
+|-----------|--------------|------|
+| **task-template.md** | Creating task issue content or defining acceptance criteria | `references/task-template.md` |
 
 ## Next Steps
 


### PR DESCRIPTION
## Description

Standardizes reference paths across all 6 skills to use simple relative paths (`references/filename.md`) instead of verbose absolute paths with `${CLAUDE_PLUGIN_ROOT}`. This change also converts the bullet-point reference format to the consistent table format used by other skills.

## Type of Change

- [x] Documentation update (improvements to README, CLAUDE.md, or component docs)

## Component(s) Affected

- [x] Skills (methodology and best practices)

## Motivation and Context

Three skills (`task-breakdown`, `prioritization`, `requirements-feedback`) were using verbose absolute paths with `${CLAUDE_PLUGIN_ROOT}`:

```markdown
- **`${CLAUDE_PLUGIN_ROOT}/skills/task-breakdown/references/task-template.md`**
```

While the other three skills (`vision-discovery`, `epic-identification`, `user-story-creation`) correctly use simple relative paths with a table format:

```markdown
| **task-template.md** | Creating task issue content | `references/task-template.md` |
```

This inconsistency makes the codebase harder to maintain. The `${CLAUDE_PLUGIN_ROOT}` variable is useful in some plugin contexts (e.g., hooks referencing scripts), but for intra-skill references to `references/` directories, simple relative paths are cleaner and match the established pattern.

Fixes #150

## How Has This Been Tested?

**Test Configuration**:
- GitHub CLI version: `gh version 2.x`
- OS: macOS

**Test Steps**:
1. Ran `markdownlint` on all modified files - passed
2. Verified all `${CLAUDE_PLUGIN_ROOT}` references removed via `grep`
3. Verified table format matches established pattern in other skills

## Checklist

### General

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings or errors

### Documentation

- [x] I have updated the documentation accordingly (README.md, CLAUDE.md, or component docs)
- [x] I have verified all links work correctly

### Markdown

- [x] I have run `markdownlint` and fixed all issues
- [x] My markdown follows the repository style (ATX headers, dash lists, fenced code blocks)

### Component-Specific Checks

#### Skills (if applicable)

- [x] Description uses third-person with specific trigger phrases
- [x] SKILL.md is under 2,000 words (progressive disclosure)
- [x] Detailed content is in `references/` subdirectory
- [x] Templates follow the established format

## Files Changed

| File | Change |
|------|--------|
| `plugins/requirements-expert/skills/task-breakdown/SKILL.md` | Converted reference from bullet to table format, replaced `${CLAUDE_PLUGIN_ROOT}` with relative path |
| `plugins/requirements-expert/skills/prioritization/SKILL.md` | Converted reference from bullet to table format, replaced `${CLAUDE_PLUGIN_ROOT}` with relative path |
| `plugins/requirements-expert/skills/requirements-feedback/SKILL.md` | Converted reference from bullet to table format, replaced `${CLAUDE_PLUGIN_ROOT}` with relative path |

## Additional Notes

All 6 skills now use the consistent table format:

| Reference | When to Load | Path |
|-----------|--------------|------|
| **filename.md** | Description of when to load | `references/filename.md` |

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)