### PR TITLE
docs(skill): improve task-breakdown reference section structure

### DIFF
--- a/plugins/requirements-expert/skills/task-breakdown/SKILL.md
+++ b/plugins/requirements-expert/skills/task-breakdown/SKILL.md
@@ -377,15 +377,22 @@ Full traceability: Vision → Epic → Story → Task
 7. **Assign** → (Optional) Assign tasks to team members
 8. **Execute** → Begin work, update task status as progress is made
 
-## Additional Resources
-
-### Reference Files
+## Reference Files
 
 Load references as needed:
 
 | Reference | When to Load | Path |
 |-----------|--------------|------|
 | **task-template.md** | Creating task issue content or defining acceptance criteria | `references/task-template.md` |
+
+## Examples
+
+Working examples that can be copied and adapted:
+
+| Example | Use Case | Path |
+|---------|----------|------|
+| **example-task-issue.md** | Creating a single task with full detail | `examples/example-task-issue.md` |
+| **example-task-set.md** | Viewing related tasks for a story | `examples/example-task-set.md` |
 
 ## Next Steps
 


### PR DESCRIPTION
## Description

Restructure the task-breakdown skill's Additional Resources section to match the table format used by sibling skills like user-story-creation. This improves progressive disclosure by making it clear when Claude should load each reference or example into context.

## Type of Change

- [x] Documentation update (improvements to README, CLAUDE.md, or component docs)

## Component(s) Affected

- [x] Skills (methodology and best practices)

## Motivation and Context

The task-breakdown skill's reference section was inconsistent with sibling skills. With the examples directory now available (via #156), this change completes the section restructuring requested in the issue.

**Changes made:**
- Renamed "Additional Resources" → "Reference Files" (removes unnecessary nesting)
- Added "Examples" section with table linking to the new example files
- Uses consistent table format with "When to Load" guidance column

Fixes #151

## How Has This Been Tested?

**Test Configuration**:
- OS: macOS 26.1 (Darwin 25.1.0)

**Test Steps**:
1. Verified markdownlint passes with no errors
2. Verified table format matches user-story-creation skill pattern
3. Confirmed example files exist at referenced paths

## Checklist

### General

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings or errors

### Documentation

- [x] I have updated the documentation accordingly
- [x] I have verified all links work correctly

### Markdown

- [x] I have run `markdownlint` and fixed all issues
- [x] My markdown follows the repository style (ATX headers, dash lists, fenced code blocks)

### Component-Specific Checks

#### Skills

- [x] Description uses third-person with specific trigger phrases
- [x] SKILL.md is under 2,000 words (progressive disclosure)
- [x] Detailed content is in `references/` subdirectory

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)