### PR TITLE
feat(skill): add cross-references between related skills

### DIFF
--- a/plugins/requirements-expert/skills/epic-identification/SKILL.md
+++ b/plugins/requirements-expert/skills/epic-identification/SKILL.md
@@ -33,7 +33,7 @@ Use epic identification when:
 - Validating that all necessary epics have been identified
 - Refining or adding to an existing set of epics
 
-**Prerequisite:** Vision must exist before identifying epics. If no vision exists, use the vision-discovery skill first.
+**Prerequisite:** Vision must exist before identifying epics. If no vision exists, use the **vision-discovery** skill first.
 
 ## Epic Identification Process
 
@@ -373,9 +373,20 @@ Working examples that can be copied and adapted:
 ## Next Steps
 
 After completing epic identification:
+
 1. Create epic issues in GitHub Projects (as children of vision issue)
-2. Prioritize epics using the prioritization skill
-3. Select highest-priority epic and proceed to user story creation
+2. Use the **prioritization** skill to apply MoSCoW priorities to epics
+3. Select highest-priority epic and proceed to the **user-story-creation** skill
 4. Iterate through all epics, creating user stories for each
+5. Use the **requirements-feedback** skill to validate epics with stakeholders
 
 Epics provide the roadmap from vision to execution—invest time to identify them comprehensively and define them clearly.
+
+## Related Skills
+
+| Skill | Relationship |
+|-------|-------------|
+| **vision-discovery** | Prerequisite—vision must exist before identifying epics |
+| **user-story-creation** | Next step—break epics into user stories |
+| **prioritization** | Use to apply MoSCoW framework to epic priorities |
+| **requirements-feedback** | Use to validate epics with stakeholders |

--- a/plugins/requirements-expert/skills/prioritization/SKILL.md
+++ b/plugins/requirements-expert/skills/prioritization/SKILL.md
@@ -424,3 +424,12 @@ Load references as needed:
 - Review and adjust regularly
 
 Prioritization is an ongoing activity throughout the requirements lifecycle—use it to focus effort on what matters most and deliver maximum value incrementally.
+
+## Related Skills
+
+| Skill | Relationship |
+|-------|-------------|
+| **epic-identification** | Apply prioritization after identifying epics |
+| **user-story-creation** | Apply prioritization after creating stories |
+| **task-breakdown** | Apply prioritization after breaking down tasks |
+| **requirements-feedback** | Use feedback to inform priority adjustments |

--- a/plugins/requirements-expert/skills/requirements-feedback/SKILL.md
+++ b/plugins/requirements-expert/skills/requirements-feedback/SKILL.md
@@ -514,3 +514,13 @@ At each transition:
 ---
 
 Requirements feedback is not a phase—it's an ongoing practice that keeps requirements aligned with reality and ensures continuous improvement throughout the product lifecycle.
+
+## Related Skills
+
+| Skill | Relationship |
+|-------|-------------|
+| **vision-discovery** | Gather feedback to validate and refine vision |
+| **epic-identification** | Gather feedback to validate epic completeness and scope |
+| **user-story-creation** | Gather feedback to validate story value and acceptance criteria |
+| **task-breakdown** | Gather implementation feedback to refine tasks |
+| **prioritization** | Use feedback insights to adjust priorities |

--- a/plugins/requirements-expert/skills/task-breakdown/SKILL.md
+++ b/plugins/requirements-expert/skills/task-breakdown/SKILL.md
@@ -33,7 +33,7 @@ Use task breakdown when:
 - Creating GitHub issues in a GitHub Project for tracking work
 - Defining clear acceptance criteria for work items
 
-**Prerequisite:** User story must exist before creating tasks. If no story exists, use user-story-creation skill first.
+**Prerequisite:** User story must exist before creating tasks. If no story exists, use the **user-story-creation** skill first.
 
 ## Task Characteristics
 
@@ -361,10 +361,21 @@ Working examples that can be copied and adapted:
 ## Next Steps
 
 After creating tasks:
+
 1. Create task issues in GitHub Projects (as children of story issue)
-2. Assign tasks to team members (if applicable)
-3. Begin execution—implement, test, document
-4. Update task status as work progresses
-5. When all tasks complete, story is complete
+2. Use the **prioritization** skill to apply MoSCoW priorities to tasks
+3. Assign tasks to team members (if applicable)
+4. Begin execution—implement, test, document
+5. Update task status as work progresses
+6. Use the **requirements-feedback** skill to gather feedback during implementation
+7. When all tasks complete, story is complete
 
 Tasks are where vision becomes reality—invest time to make them clear, testable, and actionable.
+
+## Related Skills
+
+| Skill | Relationship |
+|-------|-------------|
+| **user-story-creation** | Prerequisite—create stories before breaking down into tasks |
+| **prioritization** | Use after task creation to apply MoSCoW priorities |
+| **requirements-feedback** | Use to gather implementation feedback and refine requirements |

--- a/plugins/requirements-expert/skills/user-story-creation/SKILL.md
+++ b/plugins/requirements-expert/skills/user-story-creation/SKILL.md
@@ -28,7 +28,7 @@ Ensure user stories:
 
 ## Prerequisite
 
-Epic must exist before creating stories. If no epic exists, use epic-identification skill first.
+Epic must exist before creating stories. If no epic exists, use the **epic-identification** skill first.
 
 ## User Story Format
 
@@ -324,8 +324,18 @@ Working examples that can be copied and adapted:
 After creating user stories:
 
 1. Create story issues in GitHub Projects (as children of epic issue)
-2. Prioritize stories using the prioritization skill
-3. Select highest-priority story and proceed to task breakdown
+2. Use the **prioritization** skill to apply MoSCoW priorities to stories
+3. Select highest-priority story and proceed to the **task-breakdown** skill
 4. Iterate through all stories, creating tasks for each
+5. Use the **requirements-feedback** skill to validate stories with stakeholders
 
 User stories bridge epics and executable work. Invest time to make them clear, valuable, and testable.
+
+## Related Skills
+
+| Skill | Relationship |
+|-------|-------------|
+| **epic-identification** | Prerequisite—epics must exist before creating stories |
+| **task-breakdown** | Next step—break stories into implementable tasks |
+| **prioritization** | Use to apply MoSCoW framework to story priorities |
+| **requirements-feedback** | Use to validate stories with users and stakeholders |

--- a/plugins/requirements-expert/skills/vision-discovery/SKILL.md
+++ b/plugins/requirements-expert/skills/vision-discovery/SKILL.md
@@ -285,9 +285,18 @@ Working examples that can be copied and adapted:
 ## Next Steps
 
 After completing vision discovery:
+
 1. Create the vision issue in GitHub Projects
 2. Share with stakeholders for feedback
-3. Proceed to epic identification using the epic-identification skill
-4. Reference the vision throughout all subsequent requirements work
+3. Proceed to the **epic-identification** skill to break the vision into epics
+4. Use the **requirements-feedback** skill to gather stakeholder feedback on the vision
+5. Reference the vision throughout all subsequent requirements work
 
 The vision is the foundation—invest time to get it right before moving to epics and stories.
+
+## Related Skills
+
+| Skill | Relationship |
+|-------|-------------|
+| **epic-identification** | Next step—break vision into major capabilities (epics) |
+| **requirements-feedback** | Use to validate vision with stakeholders and users |


### PR DESCRIPTION
## Description

Add explicit cross-references to all 6 skills to help Claude understand skill relationships and workflow continuity. Each skill now includes:

- Enhanced "Prerequisite" sections with bold skill name formatting
- A "Related Skills" table showing relationships to other skills
- Updated "Next Steps" sections with explicit skill references

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update (improvements to README, CLAUDE.md, or component docs)
- [ ] Refactoring (code change that neither fixes a bug nor adds a feature)
- [ ] Configuration change (changes to .markdownlint.json, plugin.json, etc.)

## Component(s) Affected

- [ ] Commands (`/re:*`)
- [x] Skills (methodology and best practices)
- [ ] Agents (requirements-assistant, requirements-validator)
- [ ] Hooks (UserPromptSubmit)
- [ ] Documentation (README.md, CLAUDE.md, SECURITY.md)
- [ ] Configuration (.markdownlint.json, plugin.json, marketplace.json)
- [ ] Issue/PR templates
- [ ] Other (please specify):

## Motivation and Context

Skills in requirements-expert didn't reference each other explicitly, making it harder for Claude to understand skill relationships and workflow continuity. For example, the task-breakdown skill ended with generic "Next Steps" that didn't mention related skills like prioritization or requirements-feedback.

Explicit cross-references help Claude understand:
- Prerequisites (what must exist before using this skill)
- Next steps (what skills to suggest after completing work)
- Related skills (complementary skills for validation/feedback)

Fixes #154

## How Has This Been Tested?

**Test Configuration**:
- Claude Code version: Claude Opus 4.5
- GitHub CLI version: 2.x
- OS: macOS Darwin 25.1.0

**Test Steps**:
1. Ran `markdownlint plugins/requirements-expert/skills/*/SKILL.md` - all checks passed
2. Verified each skill file has consistent "Related Skills" table format
3. Verified prerequisite references use bold formatting
4. Confirmed "Next Steps" sections reference related skills explicitly

## Checklist

### General

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas (if applicable)
- [x] My changes generate no new warnings or errors

### Documentation

- [x] I have updated the documentation accordingly (README.md, CLAUDE.md, or component docs)
- [x] I have updated YAML frontmatter (if applicable) - No frontmatter changes needed
- [x] I have verified all links work correctly

### Markdown

- [x] I have run `markdownlint` and fixed all issues
- [x] My markdown follows the repository style (ATX headers, dash lists, fenced code blocks)
- [x] I have verified special HTML elements are properly closed (`<example>`, `<commentary>`, etc.)

### Component-Specific Checks

#### Skills (if applicable)

- [x] Description uses third-person with specific trigger phrases - No description changes
- [x] SKILL.md is under 2,000 words (progressive disclosure) - Only added ~10 lines per skill
- [x] Detailed content is in `references/` subdirectory - N/A
- [x] Templates follow the established format

### Testing

- [x] I have tested the plugin locally with `cc --plugin-dir plugins/requirements-expert`
- [x] I have tested the full workflow (if applicable)
- [ ] I have verified GitHub CLI integration works (if applicable) - N/A, no CLI changes
- [ ] I have tested in a clean repository (not my development repo) - N/A, documentation only

### Version Management (if applicable)

- [ ] I have updated version numbers in both `plugin.json` and `marketplace.json` (if this is a release)
- N/A - Not a release

## Additional Notes

The approach taken differs slightly from the issue's suggestion:
- Instead of only adding a "Related Skills" table, I also enhanced existing "Prerequisite" and "Next Steps" sections to use bold skill name formatting for consistency
- This provides multiple touchpoints for Claude to discover related skills

## Reviewer Notes

**Areas that need special attention**:
- Verify the "Related Skills" table format is consistent across all 6 skills
- Confirm the relationship descriptions accurately reflect the workflow

**Known limitations or trade-offs**:
- The "Related Skills" tables are placed at the end of each skill file. An alternative would be placing them near the top, but this follows the existing pattern of having "Next Steps" at the end.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)