### PR TITLE
fix(ci): resolve release drafter duplicate entries and malformed headers

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,8 +1,12 @@
 # Configuration for actions/labeler
 # Automatically applies labels to PRs based on changed files
 # See: https://github.com/actions/labeler
+#
+# Note: Semantic labels (enhancement, bug, documentation, etc.) are applied
+# by release-drafter's autolabeler based on conventional commit prefixes.
+# This file only applies component/path-based labels for filtering purposes.
 
-# Component labels
+# Component labels - for filtering PRs by what part of codebase changed
 "component:command":
   - changed-files:
       - any-glob-to-any-file: "plugins/requirements-expert/commands/**/*"
@@ -19,19 +23,26 @@
   - changed-files:
       - any-glob-to-any-file: "plugins/requirements-expert/hooks/**/*"
 
-# Documentation label - markdown files except those in component directories
+# Documentation label - only root-level docs, NOT plugin component files
+# Plugin .md files are covered by their respective component:* labels
 "component:docs":
-  - changed-files:
-      - any-glob-to-any-file:
-          - "**/*.md"
-          - "!plugins/requirements-expert/commands/**/*.md"
-          - "!plugins/requirements-expert/skills/**/*.md"
-          - "!plugins/requirements-expert/agents/**/*.md"
+  - all:
+      - changed-files:
+          - any-glob-to-any-file:
+              - "*.md"
+              - ".github/**/*.md"
+              - "docs/**/*.md"
+          - all-globs-to-all-files:
+              - "!plugins/**/*.md"
 
 # GitHub Actions workflows
 "github-actions":
   - changed-files:
-      - any-glob-to-any-file: ".github/workflows/**/*"
+      - any-glob-to-any-file:
+          - ".github/workflows/**/*"
+          - ".github/*.yml"
+          - "!.github/labeler.yml"
+          - "!.github/dependabot.yml"
 
 # Dependencies (Dependabot config)
 "dependencies":

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -6,24 +6,23 @@
 name-template: 'v$RESOLVED_VERSION'
 tag-template: 'v$RESOLVED_VERSION'
 
+# Disable default '## ' prefix since our titles include '###'
+category-template: '$TITLE'
+
 # Group PRs by label into Keep a Changelog categories
-# Order matters - first matching label determines category
+# Uses semantic labels only (not component labels) to prevent duplicates
+# Order matters - PRs appear in ALL matching categories, so labels must be mutually exclusive
 categories:
   # Keep a Changelog standard sections
-  - title: '⚠️ Breaking Changes'
+  - title: '### Breaking Changes'
     labels:
       - 'breaking'
   - title: '### Added'
     labels:
       - 'enhancement'
-      - 'component:command'
-      - 'component:skill'
-      - 'component:agent'
-      - 'component:hook'
   - title: '### Changed'
     labels:
       - 'refactor'
-      - 'automation'
   - title: '### Deprecated'
     labels:
       - 'deprecated'
@@ -43,10 +42,12 @@ categories:
   - title: '### Documentation'
     labels:
       - 'documentation'
-      - 'component:docs'
   - title: '### Dependencies'
     labels:
       - 'dependencies'
+  - title: '### CI/CD'
+    labels:
+      - 'automation'
       - 'github-actions'
 
 # Exclude certain labels from release notes
@@ -55,10 +56,44 @@ exclude-labels:
   - 'invalid'
   - 'wontfix'
   - 'stale'
+  - 'review:deep'
+  - 'review:quick'
 
 # Format for each change entry
-change-template: '- $TITLE (#$NUMBER)'
+change-template: '- $TITLE ([#$NUMBER]($URL))'
 change-title-escapes: '\<*_&'
+
+# Auto-apply semantic labels based on conventional commit prefixes
+# This ensures each PR gets exactly ONE semantic label for categorization
+autolabeler:
+  - label: 'breaking'
+    title:
+      - '/^.*!:/'
+      - '/BREAKING CHANGE/'
+    body:
+      - '/BREAKING CHANGE/'
+  - label: 'enhancement'
+    title:
+      - '/^feat(\(.+\))?:/'
+  - label: 'bug'
+    title:
+      - '/^fix(\(.+\))?:/'
+  - label: 'documentation'
+    title:
+      - '/^docs(\(.+\))?:/'
+  - label: 'refactor'
+    title:
+      - '/^refactor(\(.+\))?:/'
+  - label: 'optimization'
+    title:
+      - '/^perf(\(.+\))?:/'
+  - label: 'automation'
+    title:
+      - '/^ci(\(.+\))?:/'
+      - '/^build(\(.+\))?:/'
+  - label: 'security'
+    title:
+      - '/^security(\(.+\))?:/'
 
 # Determine version bump from labels
 version-resolver:
@@ -77,6 +112,7 @@ version-resolver:
       - 'automation'
       - 'security'
       - 'optimization'
+      - 'refactor'
   default: patch
 
 # Release notes template (Keep a Changelog format)

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -3,6 +3,8 @@ name: Release Drafter
 on:
   push:
     branches: [main]
+  # pull_request_target is required for autolabeler to work on PRs
+  # Autolabeler applies semantic labels based on conventional commit prefixes
   pull_request_target:
     types: [opened, reopened, synchronize]
 


### PR DESCRIPTION
## Summary

- Fix malformed headers (`## ### Added` → `### Added`) by adding `category-template: '$TITLE'`
- Eliminate duplicate PR entries by using semantic labels only in categories
- Add autolabeler to auto-apply labels based on conventional commit prefixes
- Fix labeler.yml exclusion patterns using correct `all` operator syntax

## Root Causes Fixed

| Issue | Cause | Fix |
|-------|-------|-----|
| `## ### Added` headers | Default `category-template: '## $TITLE'` + our `### Added` | Added `category-template: '$TITLE'` |
| Duplicate entries | PRs got multiple labels mapping to different categories | Categories now use semantic labels only |
| Label overlap | Labeler exclusion syntax was wrong | Use `all` operator with `all-globs-to-all-files` |

## Changes

### `.github/release-drafter.yml`
- Add `category-template: '$TITLE'` to disable automatic `## ` prefix
- Remove `component:*` labels from categories (these caused overlap)
- Add autolabeler section for conventional commits (`feat:` → `enhancement`, etc.)
- Add dedicated `### CI/CD` category
- Update `change-template` to include clickable PR links

### `.github/labeler.yml`
- Fix `component:docs` exclusion using correct `all` operator syntax
- Limit `component:docs` to root-level docs only (not plugin files)
- Add clarifying comments about semantic vs component labels

### `.github/workflows/release-drafter.yml`
- Add comments explaining autolabeler behavior

## Test plan

- [ ] Merge this PR and verify autolabeler applies `bug` label (from `fix:` prefix)
- [ ] Check next draft release has proper `### Fixed` header (not `## ### Fixed`)
- [ ] Verify no duplicate entries in future release notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)