### PR TITLE
docs(skill): add 'When to Use This Skill' section to prioritization

### DIFF
--- a/plugins/requirements-expert/skills/prioritization/SKILL.md
+++ b/plugins/requirements-expert/skills/prioritization/SKILL.md
@@ -19,6 +19,20 @@ Effective prioritization:
 - Aligns team and stakeholders on what matters most
 - Provides clear rationale for sequencing decisions
 
+## When to Use This Skill
+
+Use prioritization when:
+- Epics exist and need to be ordered by importance
+- Stories within an epic need priority ranking
+- Tasks need sequencing for implementation
+- User asks what to build first or what's most important
+- Applying MoSCoW labels or priority fields in GitHub Projects
+
+**Prerequisites:** Items must exist before prioritizing. If none exist:
+- No epics? Use the **epic-identification** skill first
+- No stories? Use the **user-story-creation** skill first
+- No tasks? Use the **task-breakdown** skill first
+
 ## MoSCoW Framework
 
 ### Must Have


### PR DESCRIPTION
## Description

Add the missing "When to Use This Skill" section to the prioritization skill, following the pattern established by sibling skills (epic-identification, task-breakdown). This section clarifies when the skill should be triggered and what prerequisites must exist.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update (improvements to README, CLAUDE.md, or component docs)
- [ ] Refactoring (code change that neither fixes a bug nor adds a feature)
- [ ] Configuration change (changes to .markdownlint.json, plugin.json, etc.)

## Component(s) Affected

- [ ] Commands (`/re:*`)
- [x] Skills (methodology and best practices)
- [ ] Agents (requirements-assistant, requirements-validator)
- [ ] Hooks (UserPromptSubmit)
- [ ] Documentation (README.md, CLAUDE.md, SECURITY.md)
- [ ] Configuration (.markdownlint.json, plugin.json, marketplace.json)
- [ ] Issue/PR templates
- [ ] Other (please specify):

## Motivation and Context

The prioritization skill was missing a "When to Use This Skill" section that other skills have. This section:
- Clarifies when the skill should be triggered
- Documents prerequisites (items must exist before prioritizing)
- Cross-references related skills when prerequisites aren't met

Fixes #163

## How Has This Been Tested?

**Test Configuration**:
- Claude Code version: Latest
- GitHub CLI version: 2.x
- OS: macOS

**Test Steps**:
1. Ran `markdownlint plugins/requirements-expert/skills/prioritization/SKILL.md` - passed with no errors
2. Verified the new section follows the same structure as epic-identification (lines 27-36) and task-breakdown (lines 27-36)
3. Confirmed placement is correct: after "Purpose" section, before "MoSCoW Framework" section

## Checklist

### General

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas (if applicable)
- [x] My changes generate no new warnings or errors

### Documentation

- [x] I have updated the documentation accordingly (README.md, CLAUDE.md, or component docs)
- [x] I have updated YAML frontmatter (if applicable) - N/A (no frontmatter changes)
- [x] I have verified all links work correctly

### Markdown

- [x] I have run `markdownlint` and fixed all issues
- [x] My markdown follows the repository style (ATX headers, dash lists, fenced code blocks)
- [x] I have verified special HTML elements are properly closed (`<example>`, `<commentary>`, etc.)

### Component-Specific Checks

#### Skills (if applicable)

- [x] Description uses third-person with specific trigger phrases
- [x] SKILL.md is under 2,000 words (progressive disclosure)
- [x] Detailed content is in `references/` subdirectory - N/A (no new reference content)
- [x] Templates follow the established format

### Testing

- [ ] I have tested the plugin locally with `cc --plugin-dir plugins/requirements-expert`
- [ ] I have tested the full workflow (if applicable)
- [ ] I have verified GitHub CLI integration works (if applicable)
- [ ] I have tested in a clean repository (not my development repo)

Note: This is a documentation-only change that adds a new section to an existing skill. The change follows established patterns from sibling skills and requires no functional testing.

### Version Management (if applicable)

- [ ] I have updated version numbers in both `plugin.json` and `marketplace.json` (if this is a release)

N/A - This is not a release, just a documentation enhancement.

## Additional Notes

The new section follows the exact pattern from:
- `skills/epic-identification/SKILL.md` (lines 27-36)
- `skills/task-breakdown/SKILL.md` (lines 27-36)

The section is placed after "Purpose" and before "MoSCoW Framework" to maintain logical document flow.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)