### PR TITLE
docs(skill): expand prioritization description trigger phrases

### DIFF
--- a/plugins/requirements-expert/skills/prioritization/SKILL.md
+++ b/plugins/requirements-expert/skills/prioritization/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: Prioritization
-description: This skill should be used when the user asks to "prioritize requirements", "use MoSCoW", "prioritize epics", "prioritize stories", "prioritize tasks", "what should I build first", "rank features", or when they need to determine the priority order of epics, user stories, or tasks using the MoSCoW framework.
+description: This skill should be used when the user asks to "prioritize requirements", "prioritize epics", "prioritize stories", "prioritize tasks", "prioritize backlog", "use MoSCoW", "apply MoSCoW priorities", "assign priorities", "set priority labels", "rank features", "what should I build first", "what's most important", "order by importance", "must have vs should have", or when they need to determine the priority order of epics, user stories, or tasks using the MoSCoW framework.
 version: 0.2.0
 ---
 


### PR DESCRIPTION
## Description

Expand trigger phrases in the prioritization skill frontmatter from 7 to 14 phrases for improved skill triggering coverage. The added phrases align with common user terminology for prioritization workflows.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to README, CLAUDE.md, or component docs)
- [ ] Refactoring (code change that neither fixes a bug nor adds a feature)
- [ ] Configuration change (changes to .markdownlint.json, plugin.json, etc.)

## Component(s) Affected

- [ ] Commands (`/re:*`)
- [x] Skills (methodology and best practices)
- [ ] Agents (requirements-assistant, requirements-validator)
- [ ] Hooks (UserPromptSubmit)
- [ ] Documentation (README.md, CLAUDE.md, SECURITY.md)
- [ ] Configuration (.markdownlint.json, plugin.json, marketplace.json)
- [ ] Issue/PR templates
- [ ] Other (please specify):

## Motivation and Context

The prioritization skill had only 7 trigger phrases, which may cause the skill to not load when users ask about prioritization using different phrasing. Other skills (e.g., epic-identification with 10 phrases, task-breakdown with 12 phrases) have more comprehensive trigger phrase coverage.

Fixes #164

## Changes Made

**Previous trigger phrases (7):**
- "prioritize requirements"
- "use MoSCoW"
- "prioritize epics"
- "prioritize stories"
- "prioritize tasks"
- "what should I build first"
- "rank features"

**New trigger phrases (14 total, +7 added):**
- "prioritize backlog" - Agile terminology
- "apply MoSCoW priorities" - action-oriented
- "assign priorities" - common phrasing
- "set priority labels" - GitHub-specific action
- "what's most important" - conversational
- "order by importance" - action-oriented
- "must have vs should have" - MoSCoW-specific

## How Has This Been Tested?

**Test Configuration**:
- Claude Code version: Latest
- GitHub CLI version: 2.x
- OS: macOS

**Test Steps**:
1. Ran `markdownlint plugins/requirements-expert/skills/prioritization/SKILL.md` - passed
2. Verified YAML frontmatter syntax is valid
3. Confirmed new phrase count (14) aligns with other skills

## Checklist

### General

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings or errors

### Documentation

- [x] I have updated YAML frontmatter (if applicable)

### Markdown

- [x] I have run `markdownlint` and fixed all issues
- [x] My markdown follows the repository style (ATX headers, dash lists, fenced code blocks)

### Component-Specific Checks

#### Skills (if applicable)

- [x] Description uses third-person with specific trigger phrases
- [x] SKILL.md is under 2,000 words (progressive disclosure)

### Testing

- [x] I have tested the plugin locally with `cc --plugin-dir plugins/requirements-expert`

## Additional Notes

The reorganization groups related phrases together:
1. "prioritize X" phrases grouped at start
2. "MoSCoW" phrases grouped together
3. Action phrases ("assign", "set") grouped
4. Conversational phrases at end

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)