### PR TITLE
docs(skill): remove horizontal rules from prioritization SKILL.md

### DIFF
--- a/plugins/requirements-expert/skills/prioritization/SKILL.md
+++ b/plugins/requirements-expert/skills/prioritization/SKILL.md
@@ -58,8 +58,6 @@ Use prioritization when:
 
 **Typical Percentage:** 60% of total requirements
 
----
-
 ### Should Have
 
 **Definition:** Important requirements that significantly enhance value but aren't absolutely critical for initial release. Can be deferred if necessary.
@@ -83,8 +81,6 @@ Use prioritization when:
 - Would delaying this cause pain but not failure?
 
 **Typical Percentage:** 20% of total requirements
-
----
 
 ### Could Have
 
@@ -110,8 +106,6 @@ Use prioritization when:
 
 **Typical Percentage:** 20% of total requirements
 
----
-
 ### Won't Have (This Time)
 
 **Definition:** Requirements explicitly excluded from current scope. May be considered for future releases but are off the table now.
@@ -135,8 +129,6 @@ Use prioritization when:
 - Can we explicitly say "not now" to this?
 
 **Purpose:** Prevents scope creep by making exclusions explicit
-
----
 
 ## Prioritization Process
 


### PR DESCRIPTION
## Description

Remove 4 excessive horizontal rules (`---`) between MoSCoW category sections in the prioritization SKILL.md. Standard markdown heading hierarchy (`###`) provides sufficient visual separation and is consistent with other skills in the plugin.

## Type of Change

- [x] Documentation update (improvements to README, CLAUDE.md, or component docs)

## Component(s) Affected

- [x] Skills (methodology and best practices)

## Motivation and Context

The prioritization SKILL.md was inconsistent with other skills in the plugin. While epic-identification, task-breakdown, vision-discovery, and user-story-creation use only heading hierarchy for section separation, prioritization had horizontal rules cluttering the content between MoSCoW categories.

Fixes #167

## How Has This Been Tested?

**Test Configuration**:
- GitHub CLI version: gh version 2.x
- OS: macOS

**Test Steps**:
1. Verified markdownlint passes: `markdownlint plugins/requirements-expert/skills/prioritization/SKILL.md`
2. Verified only frontmatter `---` remain (lines 1 and 5)
3. Compared with other skills to confirm consistency

## Checklist

### General

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings or errors

### Documentation

- [x] I have verified all links work correctly

### Markdown

- [x] I have run `markdownlint` and fixed all issues
- [x] My markdown follows the repository style (ATX headers, dash lists, fenced code blocks)

### Component-Specific Checks

#### Skills

- [x] SKILL.md is under 2,000 words (progressive disclosure)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)