### PR TITLE
docs(skill): fix second-person language in prioritization SKILL.md

### DIFF
--- a/plugins/requirements-expert/skills/prioritization/SKILL.md
+++ b/plugins/requirements-expert/skills/prioritization/SKILL.md
@@ -21,7 +21,7 @@ Effective prioritization:
 
 ## When to Use This Skill
 
-Use prioritization when:
+Apply this skill when:
 - Epics exist and need to be ordered by importance
 - Stories within an epic need priority ranking
 - Tasks need sequencing for implementation
@@ -247,7 +247,7 @@ See `references/moscow-worksheet.md` for the complete GitHub update workflow.
 - Strategic alignment with vision
 - Foundation vs. enhancement (build foundation first)
 - User journey completeness (can users accomplish goals?)
-- Market differentiation (what makes you unique?)
+- Market differentiation (what differentiates the product?)
 
 **Example:**
 - Must Have: User Authentication, Core Workflow, Payment Processing


### PR DESCRIPTION
## Summary

Fix remaining second-person language in the prioritization skill to follow Claude Code plugin best practices.

Fixes #176

## Problem

The prioritization SKILL.md contained scattered instances of second-person or implied-you language, which doesn't follow the Claude Code plugin skill best practice of using imperative/infinitive form.

## Solution

Replace implied-you and second-person pronouns with imperative form:

| Line | Original | Fixed |
|------|----------|-------|
| 24 | "Use prioritization when:" | "Apply this skill when:" |
| 250 | "what makes you unique?" | "what differentiates the product?" |

### Note on Issue Scope

The original issue identified 5 instances to fix. However, 3 of those were already resolved by earlier PRs:
- PR #173 (Reframe SKILL.md for AI consumption)  
- PR #175 (Extract best practices)

Only 2 instances remained in the current file, plus 1 additional instance discovered during implementation.

## Changes

- `plugins/requirements-expert/skills/prioritization/SKILL.md`: Replace 2 instances of second-person language

## Testing

- [x] `markdownlint` passes
- [x] No remaining `you/your` pronouns in file (verified with grep)

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Changes are focused and minimal

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)