### PR TITLE
docs(skill): add field ID retrieval guidance to prioritization Step 6

### DIFF
--- a/plugins/requirements-expert/skills/prioritization/SKILL.md
+++ b/plugins/requirements-expert/skills/prioritization/SKILL.md
@@ -217,7 +217,17 @@ Within each MoSCoW category, establish order:
 
 Persist prioritization decisions using GitHub CLI:
 
+**Retrieve Field ID First:**
+
+Before updating fields, retrieve the Priority field ID:
+
+```bash
+gh project field-list [project-number] --owner [owner] --format json | jq '.fields[] | select(.name=="Priority") | .id'
+```
+
 **Update Priority Custom Field:**
+
+Use the retrieved field ID to update items:
 
 ```bash
 gh project item-edit --id [item-id] --field-id [priority-field-id] --value "[priority]"


### PR DESCRIPTION
## Description

Adds explicit guidance on retrieving the Priority field ID before updating project items in the prioritization skill's Step 6. This makes the SKILL.md self-contained for the field update workflow.

## Type of Change

- [x] Documentation update (improvements to README, CLAUDE.md, or component docs)

## Component(s) Affected

- [x] Skills (methodology and best practices)

## Motivation and Context

Step 6 showed the `gh project item-edit --id [item-id] --field-id [priority-field-id] --value "[priority]"` command but didn't explain how to obtain the `[priority-field-id]` value. While the `/re:prioritize` command handles this internally, the skill documentation should be self-contained for reference.

Fixes #184

## How Has This Been Tested?

**Test Configuration**:
- Markdown linting: `markdownlint plugins/requirements-expert/skills/prioritization/SKILL.md` - passes

**Test Steps**:
1. Reviewed that the added `gh project field-list` command matches the pattern already used in `references/moscow-worksheet.md`
2. Verified the guidance is placed before the "Update Priority Custom Field" section as suggested in the issue
3. Confirmed markdownlint passes with no errors

## Checklist

### General

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings or errors

### Documentation

- [x] I have updated the documentation accordingly
- [x] I have verified all links work correctly

### Markdown

- [x] I have run `markdownlint` and fixed all issues
- [x] My markdown follows the repository style (ATX headers, dash lists, fenced code blocks)

### Component-Specific Checks

#### Skills

- [x] SKILL.md is under 2,000 words (progressive disclosure)
- [x] Content follows existing patterns in the file

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)