### PR TITLE
fix(skill): use kebab-case for skill name frontmatter

### DIFF
--- a/plugins/requirements-expert/skills/epic-identification/SKILL.md
+++ b/plugins/requirements-expert/skills/epic-identification/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: Epic Identification
+name: epic-identification
 description: |
   This skill should be used when the user asks to "identify epics", "break down vision into epics", "find major features", "discover capability areas", "decompose vision", "group requirements into themes", "define high-level features", "what epics do I need", "turn vision into work items", or "split project into epics". Provides methodology for deriving epics from a vision statement using user journey mapping, capability decomposition, and stakeholder analysis.
 version: 0.2.0

--- a/plugins/requirements-expert/skills/prioritization/SKILL.md
+++ b/plugins/requirements-expert/skills/prioritization/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: Prioritization
+name: prioritization
 description: This skill should be used when the user asks to "prioritize requirements", "prioritize epics", "prioritize stories", "prioritize tasks", "prioritize backlog", "use MoSCoW", "apply MoSCoW priorities", "assign priorities", "set priority labels", "rank features", "what should I build first", "what's most important", "order by importance", "must have vs should have", or when they need to determine the priority order of epics, user stories, or tasks using the MoSCoW framework.
 version: 0.2.0
 ---

--- a/plugins/requirements-expert/skills/requirements-feedback/SKILL.md
+++ b/plugins/requirements-expert/skills/requirements-feedback/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: Requirements Feedback
+name: requirements-feedback
 description: This skill should be used when the user asks about "feedback loops", "iterate on requirements", "continuous documentation", "refine requirements", "update requirements", "requirements changed", or when they need guidance on gathering feedback and continuously improving requirements throughout the product lifecycle.
 version: 0.2.0
 ---

--- a/plugins/requirements-expert/skills/task-breakdown/SKILL.md
+++ b/plugins/requirements-expert/skills/task-breakdown/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: Task Breakdown
+name: task-breakdown
 description: This skill should be used when the user asks to "create tasks", "break down story into tasks", "define tasks", "what tasks are needed", "write acceptance criteria", "implementation tasks", "task list", "create work items", "technical tasks", "work breakdown", "decompose story", "story to tasks", or when decomposing user stories into specific, executable tasks with clear acceptance criteria for GitHub Projects.
 version: 0.2.0
 ---

--- a/plugins/requirements-expert/skills/user-story-creation/SKILL.md
+++ b/plugins/requirements-expert/skills/user-story-creation/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: User Story Creation
+name: user-story-creation
 description: This skill should be used when the user asks to "create user stories", "write user stories", "break down epic into stories", "define user stories", "what stories do I need", "apply INVEST criteria", "write acceptance criteria", "split a large story", "story is too big", "story splitting", or when decomposing epics into specific, valuable user stories.
 version: 0.2.0
 ---

--- a/plugins/requirements-expert/skills/vision-discovery/SKILL.md
+++ b/plugins/requirements-expert/skills/vision-discovery/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: Vision Discovery
+name: vision-discovery
 description: This skill should be used when the user asks to "discover vision", "create a vision", "define product vision", "document vision", "what should my vision be", "help me with vision", "start requirements from scratch", "begin new product planning", "define product direction", "establish product vision", or when starting a new requirements project and needs to establish the foundational product vision before identifying epics or stories.
 version: 0.2.0
 ---


### PR DESCRIPTION
## Summary

- Update all 6 SKILL.md files to use lowercase kebab-case for the `name` field
- Aligns with official Claude Code skill documentation: "Must use lowercase letters, numbers, and hyphens only (max 64 characters)"

| Before | After |
|--------|-------|
| Epic Identification | epic-identification |
| Prioritization | prioritization |
| Requirements Feedback | requirements-feedback |
| Task Breakdown | task-breakdown |
| User Story Creation | user-story-creation |
| Vision Discovery | vision-discovery |

## Reference

https://code.claude.com/docs/en/skills#write-skill-md

## Test plan

- [ ] Verify skills still load correctly with `cc --plugin-dir plugins/requirements-expert`
- [ ] Confirm skill triggering works as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)