### PR TITLE
docs(skill): fix writing style in requirements-feedback to use imperative form

### DIFF
--- a/plugins/requirements-expert/skills/requirements-feedback/SKILL.md
+++ b/plugins/requirements-expert/skills/requirements-feedback/SKILL.md
@@ -82,7 +82,7 @@ Each level of the requirements hierarchy has distinct feedback needs. For detail
 - Add clarifications when questions arise
 - Document decisions made during implementation
 
-### Document What You Learn
+### Document Learnings
 
 - Add comments to issues with findings from user research
 - Link to test results or analytics that inform requirements
@@ -104,7 +104,7 @@ Each level of the requirements hierarchy has distinct feedback needs. For detail
 - Make it safe to say "this requirement doesn't make sense"
 - Reward people who catch problems early
 - Avoid blame when requirements change
-- Ask open questions: "What are we missing?"
+- Ask open questions: "What is missing?"
 
 ### Act on Feedback Quickly
 
@@ -132,7 +132,7 @@ Each level of the requirements hierarchy has distinct feedback needs. For detail
 - Get outside perspective regularly
 - Test assumptions with actual users
 - Observe real usage, not just opinions
-- Don't wait for "finished" to get feedback
+- Gather feedback early, before reaching completion
 
 ## Common Pitfalls to Avoid
 

--- a/plugins/requirements-expert/skills/requirements-feedback/references/feedback-checklist.md
+++ b/plugins/requirements-expert/skills/requirements-feedback/references/feedback-checklist.md
@@ -24,23 +24,23 @@ Use this checklist to ensure comprehensive feedback collection and incorporation
 
 **User Validation:**
 - [ ] Are target user descriptions accurate?
-- [ ] Have we identified all key user types?
-- [ ] Do we understand their context and constraints?
+- [ ] Are all key user types identified?
+- [ ] Is user context and constraints documented?
 
 **Solution Validation:**
 - [ ] Does the solution vision make sense to stakeholders?
 - [ ] Is the value proposition compelling?
-- [ ] Are there alternative approaches we should consider?
+- [ ] Are there alternative approaches to consider?
 
 **Strategic Alignment:**
 - [ ] Does this align with business goals and strategy?
 - [ ] Is timing right for this initiative?
-- [ ] Do we have resources and commitment?
+- [ ] Are resources and commitment secured?
 
 **Success Metrics:**
 - [ ] Are success metrics measurable and realistic?
 - [ ] Do metrics align with business objectives?
-- [ ] Can we actually track these metrics?
+- [ ] Can these metrics be tracked?
 
 **Scope & Boundaries:**
 - [ ] Are boundaries clear and appropriate?
@@ -140,7 +140,7 @@ Use this checklist to ensure comprehensive feedback collection and incorporation
 **Value:**
 - [ ] Does each story deliver user-facing value?
 - [ ] Are priorities appropriate?
-- [ ] Can we explain "why" for each story?
+- [ ] Can the "why" for each story be explained?
 
 ### Actions
 
@@ -183,9 +183,9 @@ Use this checklist to ensure comprehensive feedback collection and incorporation
 
 **Implementation Feedback:**
 - [ ] Are actual results matching expected outcomes?
-- [ ] Have we discovered missing tasks?
+- [ ] Have missing tasks been discovered?
 - [ ] Are estimates accurate?
-- [ ] Have we learned anything that should update the story?
+- [ ] Have any learnings emerged that should update the story?
 
 ### Actions
 
@@ -220,17 +220,17 @@ Use this checklist to ensure comprehensive feedback collection and incorporation
 - [ ] What issues are users encountering?
 - [ ] What's confusing or difficult?
 - [ ] What's missing that users need?
-- [ ] What feedback are we getting from support?
+- [ ] What feedback is coming from support?
 
 **Opportunities:**
 - [ ] What enhancements would increase value?
 - [ ] What related needs have been discovered?
-- [ ] What should we build next?
+- [ ] What should be built next?
 
 **Validation:**
-- [ ] Were our assumptions correct?
-- [ ] What did we get wrong?
-- [ ] What did we learn?
+- [ ] Were initial assumptions correct?
+- [ ] What assumptions proved incorrect?
+- [ ] What learnings emerged?
 
 ### Actions
 
@@ -322,8 +322,8 @@ Use this checklist to ensure comprehensive feedback collection and incorporation
 
 ### 7. Document Learnings
 
-- [ ] What did we learn?
-- [ ] How can we improve future requirements?
+- [ ] What learnings emerged?
+- [ ] How can future requirements be improved?
 - [ ] What patterns are emerging?
 - [ ] Update processes based on learnings
 
@@ -419,4 +419,4 @@ Use this checklist to ensure comprehensive feedback collection and incorporation
 
 ---
 
-Use this checklist to establish regular, effective feedback loops that keep your requirements aligned with user needs and stakeholder goals throughout the product lifecycle.
+Use this checklist to establish regular, effective feedback loops that keep requirements aligned with user needs and stakeholder goals throughout the product lifecycle.

--- a/plugins/requirements-expert/skills/requirements-feedback/references/feedback-techniques.md
+++ b/plugins/requirements-expert/skills/requirements-feedback/references/feedback-techniques.md
@@ -18,7 +18,7 @@ Detailed methods and guidance for collecting feedback from different sources thr
 - **Vision validation:** Does the problem resonate with target users?
 - **Epic prioritization:** What capabilities matter most to users?
 - **Story refinement:** Does the proposed solution work for users?
-- **Post-launch:** Are we delivering expected value?
+- **Post-launch:** Is expected value being delivered?
 
 ### Incorporating Results
 
@@ -123,7 +123,7 @@ Detailed methods and guidance for collecting feedback from different sources thr
 
 ### Preparation
 
-- Define what you want to learn before gathering feedback
+- Define learning objectives before gathering feedback
 - Prepare specific questions or hypotheses to validate
 - Identify the right participants or data sources
 - Allocate adequate time for feedback collection and analysis


### PR DESCRIPTION
## Description

Convert second person ("you/your") to imperative form and first person ("we/our") to passive voice across the requirements-feedback skill to align with skill-development best practices, which require verb-first, objective language.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update (improvements to README, CLAUDE.md, or component docs)
- [ ] Refactoring (code change that neither fixes a bug nor adds a feature)
- [ ] Configuration change (changes to .markdownlint.json, plugin.json, etc.)

## Component(s) Affected

- [ ] Commands (`/re:*`)
- [x] Skills (methodology and best practices)
- [ ] Agents (requirements-assistant, requirements-validator)
- [ ] Hooks (UserPromptSubmit)
- [ ] Documentation (README.md, CLAUDE.md, SECURITY.md)
- [ ] Configuration (.markdownlint.json, plugin.json, marketplace.json)
- [ ] Issue/PR templates
- [ ] Other (please specify):

## Motivation and Context

Per the skill-development best practices guide:

> **Writing Style:** Write the entire skill using **imperative/infinitive form** (verb-first instructions), not second person. Use objective, instructional language (e.g., "To accomplish X, do Y" rather than "You should do X" or "If you need to do X").

This PR fixes writing style violations found in the requirements-feedback skill files.

Fixes #194

## Changes Made

### SKILL.md (3 changes)
| Line | Before | After |
|------|--------|-------|
| 85 | "Document What You Learn" | "Document Learnings" |
| 107 | "What are we missing?" | "What is missing?" |
| 135 | "Don't wait for 'finished' to get feedback" | "Gather feedback early, before reaching completion" |

### references/feedback-checklist.md (18 changes)
| Type | Before | After |
|------|--------|-------|
| First person | "Have we identified..." | "Are...identified?" |
| First person | "Do we understand..." | "Is...documented?" |
| First person | "we should consider" | "to consider" |
| First person | "Do we have resources..." | "Are resources...secured?" |
| First person | "Can we track..." | "Can...be tracked?" |
| First person | "Can we explain..." | "Can...be explained?" |
| First person | "Have we discovered/learned..." | Passive voice |
| First person | "are we getting/delivering" | Passive voice |
| First person | "our assumptions" | "initial assumptions" |
| Second person | "your requirements" | "requirements" |

### references/feedback-techniques.md (2 changes)
| Line | Before | After |
|------|--------|-------|
| 21 | "Are we delivering expected value?" | "Is expected value being delivered?" |
| 126 | "Define what you want to learn" | "Define learning objectives" |

## How Has This Been Tested?

**Test Configuration**:
- Claude Code version: Latest
- GitHub CLI version: 2.x
- OS: macOS

**Test Steps**:
1. Ran `grep` to identify all instances of "you/your/we/our" patterns
2. Applied fixes following the style guide
3. Verified no remaining violations with `grep` search
4. Ran `markdownlint plugins/requirements-expert/skills/requirements-feedback/**/*.md` - passed

## Checklist

### General

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas (if applicable)
- [x] My changes generate no new warnings or errors

### Documentation

- [x] I have updated the documentation accordingly (README.md, CLAUDE.md, or component docs)
- [ ] I have updated YAML frontmatter (if applicable) - Not applicable
- [x] I have verified all links work correctly

### Markdown

- [x] I have run `markdownlint` and fixed all issues
- [x] My markdown follows the repository style (ATX headers, dash lists, fenced code blocks)
- [x] I have verified special HTML elements are properly closed (`<example>`, `<commentary>`, etc.)

### Component-Specific Checks

#### Skills (if applicable)

- [x] Description uses third-person with specific trigger phrases
- [x] SKILL.md is under 2,000 words (progressive disclosure)
- [x] Detailed content is in `references/` subdirectory
- [x] Templates follow the established format

### Testing

- [ ] I have tested the plugin locally with `cc --plugin-dir plugins/requirements-expert` - Not required for style-only changes
- [ ] I have tested the full workflow (if applicable) - Not applicable
- [ ] I have verified GitHub CLI integration works (if applicable) - Not applicable
- [ ] I have tested in a clean repository (not my development repo) - Not applicable

### Version Management (if applicable)

Not applicable for this documentation-only change.

## Reviewer Notes

**Areas that need special attention**:
- Verify the passive voice conversions maintain readability while removing first/second person
- Confirm the checklist questions still make sense in passive form

**Known limitations or trade-offs**:
- Some passive voice constructions are slightly longer but maintain the instructional tone required by the style guide

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)