### PR TITLE
docs(skill): expand trigger phrases in requirements-feedback description

### DIFF
--- a/plugins/requirements-expert/skills/requirements-feedback/SKILL.md
+++ b/plugins/requirements-expert/skills/requirements-feedback/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: requirements-feedback
-description: This skill should be used when the user asks about "feedback loops", "iterate on requirements", "continuous documentation", "refine requirements", "update requirements", "requirements changed", or when they need guidance on gathering feedback and continuously improving requirements throughout the product lifecycle.
+description: This skill should be used when the user asks about "feedback loops", "iterate on requirements", "continuous documentation", "refine requirements", "update requirements", "requirements changed", "stakeholder review", "validate requirements", "incorporate feedback", "gather feedback", "requirements review meeting", "backlog refinement feedback", "user research findings", "sprint retrospective feedback", or when they need guidance on collecting and incorporating feedback throughout the requirements lifecycle.
 version: 0.2.0
 ---
 


### PR DESCRIPTION
## Summary

Expands the trigger phrases in the requirements-feedback skill description from 6 to 14 phrases, improving skill discoverability when users ask about various feedback-related topics.

## Problem

The skill's trigger phrases were limited and didn't cover many common action-oriented phrases that users would naturally say, such as "stakeholder review" or "validate requirements".

Fixes #195

## Solution

Added 8 additional trigger phrases to the YAML frontmatter description:
- stakeholder review
- validate requirements
- incorporate feedback
- gather feedback
- requirements review meeting
- backlog refinement feedback
- user research findings
- sprint retrospective feedback

Also refined the closing clause from "gathering feedback and continuously improving requirements throughout the product lifecycle" to "collecting and incorporating feedback throughout the requirements lifecycle" for better consistency.

## Changes

- `plugins/requirements-expert/skills/requirements-feedback/SKILL.md`: Updated description in YAML frontmatter

## Testing

- [x] Linting passes (`markdownlint`)
- [x] YAML frontmatter syntax validated
- [x] Trigger phrases match skill content coverage

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Changes are focused and minimal

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)