### PR TITLE
docs(skill): add examples reference to requirements-feedback SKILL.md

### DIFF
--- a/plugins/requirements-expert/skills/requirements-feedback/SKILL.md
+++ b/plugins/requirements-expert/skills/requirements-feedback/SKILL.md
@@ -16,6 +16,7 @@ Then determine their current need:
 2. **Stage-specific guidance** (user asks about feedback for a specific level) - Load `references/stage-feedback-guide.md`
 3. **Running a review** (user wants to validate or check requirements) - Load `references/feedback-checklist.md`
 4. **Incorporating feedback** (user has feedback to act on) - Follow the 7-step Quick Reference workflow below
+5. **See a complete example** (user wants to see how feedback workflow works end-to-end) - Load `examples/feedback-workflow-example.md`
 
 Guide users through the feedback workflow:
 
@@ -187,6 +188,14 @@ Load references as needed:
 | **stage-feedback-guide.md** | Detailed guidance for feedback at each requirements level (Vision, Epic, Story, Task) | `references/stage-feedback-guide.md` |
 | **feedback-techniques.md** | Methods for user research, stakeholder reviews, team feedback, and automated feedback | `references/feedback-techniques.md` |
 | **feedback-checklist.md** | Conducting feedback reviews or validating requirements at any level | `references/feedback-checklist.md` |
+
+## Examples
+
+Working examples that can be copied and adapted:
+
+| Example | Use Case | Path |
+|---------|----------|------|
+| **feedback-workflow-example.md** | Complete end-to-end feedback collection and incorporation cycle | `examples/feedback-workflow-example.md` |
 
 ## Integration with Requirements Lifecycle
 


### PR DESCRIPTION
## Description

Add references to the examples directory in the requirements-feedback skill to make the `feedback-workflow-example.md` discoverable. The example file exists and contains ~2,000 words of high-quality content but was not referenced from SKILL.md.

## Type of Change

- [x] Documentation update (improvements to README, CLAUDE.md, or component docs)

## Component(s) Affected

- [x] Skills (methodology and best practices)

## Motivation and Context

The requirements-feedback skill has an excellent example file (`examples/feedback-workflow-example.md`) that demonstrates a complete end-to-end feedback workflow. However, this file was not discoverable from SKILL.md because:

1. The "When This Skill Loads" section didn't include a scenario for loading the example
2. There was no "Examples" section in SKILL.md (unlike other skills like vision-discovery and epic-identification)

This gap was identified during a skill review where the Cross-References score was 7.5/10.

Fixes #204

## How Has This Been Tested?

**Test Configuration**:
- Claude Code version: Latest
- GitHub CLI version: 2.x
- OS: macOS

**Test Steps**:
1. Ran `markdownlint plugins/requirements-expert/skills/requirements-feedback/SKILL.md` - passed
2. Verified the structure matches other skills (vision-discovery, epic-identification)

## Checklist

### General

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings or errors

### Documentation

- [x] I have updated the documentation accordingly (README.md, CLAUDE.md, or component docs)
- [x] I have verified all links work correctly

### Markdown

- [x] I have run `markdownlint` and fixed all issues
- [x] My markdown follows the repository style (ATX headers, dash lists, fenced code blocks)

### Component-Specific Checks

#### Skills (if applicable)

- [x] SKILL.md is under 2,000 words (progressive disclosure)
- [x] Detailed content is in `references/` subdirectory

## Additional Notes

The implementation follows the established pattern used in other skills:
- **vision-discovery/SKILL.md**: Has separate "Reference Files" and "Examples" sections
- **epic-identification/SKILL.md**: Has separate "Reference Files" and "Examples" sections

This approach is cleaner than the original issue suggestion of combining references and examples into one table.

## Reviewer Notes

**Areas that need special attention**:
- Verify the new "Examples" section formatting matches other skills

**Known limitations or trade-offs**:
- None

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)