### PR TITLE
docs(skill): add command integration guidance to requirements-feedback

### DIFF
--- a/plugins/requirements-expert/skills/requirements-feedback/SKILL.md
+++ b/plugins/requirements-expert/skills/requirements-feedback/SKILL.md
@@ -205,6 +205,20 @@ At each transition:
 
 Requirements feedback is not a phase—it's an ongoing practice that keeps requirements aligned with reality and ensures continuous improvement throughout the product lifecycle.
 
+## Command Integration
+
+This skill complements the `/re:*` commands. Use the appropriate tool for each scenario:
+
+| Scenario | Recommended Tool |
+|----------|------------------|
+| Validate structure and INVEST compliance | `/re:review` command |
+| Check project status and hierarchy | `/re:status` command |
+| Collect stakeholder feedback | This skill + `references/feedback-techniques.md` |
+| Run a feedback review meeting | This skill + `references/feedback-checklist.md` |
+| Incorporate feedback into requirements | This skill + Quick Reference workflow |
+
+**Workflow:** Run `/re:review` for automated validation, then use this skill for human feedback collection and incorporation.
+
 ## Related Skills
 
 | Skill | Relationship |


### PR DESCRIPTION
## Description

Add a new "Command Integration" section to the requirements-feedback skill that clarifies when to use `/re:review` and `/re:status` commands versus this skill for feedback workflows.

## Type of Change

- [x] Documentation update (improvements to README, CLAUDE.md, or component docs)

## Component(s) Affected

- [x] Skills (methodology and best practices)

## Motivation and Context

Users may not know which tool to use for different scenarios:
- When should they use `/re:review` command?
- When should they use this skill?
- How do they work together?

This section clarifies the handoff between automated validation (`/re:review`) and human-driven feedback workflows (this skill).

Fixes #206

## How Has This Been Tested?

**Test Configuration**:
- Claude Code version: Latest
- OS: macOS

**Test Steps**:
1. Verified markdown linting passes: `markdownlint plugins/requirements-expert/skills/requirements-feedback/SKILL.md`
2. Reviewed section placement and table formatting

## Checklist

### General

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings or errors

### Documentation

- [x] I have updated the documentation accordingly
- [x] I have verified all links work correctly

### Markdown

- [x] I have run `markdownlint` and fixed all issues
- [x] My markdown follows the repository style (ATX headers, dash lists, fenced code blocks)

### Component-Specific Checks

#### Skills

- [x] SKILL.md is under 2,000 words (progressive disclosure)

### Testing

- [x] I have tested the plugin locally

## Additional Notes

The new section includes:
- A scenario table mapping requirements tasks to recommended tools
- Clear workflow guidance: run `/re:review` for automated validation, then use this skill for human feedback

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)