### PR TITLE
feat(skill): add action-oriented trigger phrases to requirements-feedback

### DIFF
--- a/plugins/requirements-expert/skills/requirements-feedback/SKILL.md
+++ b/plugins/requirements-expert/skills/requirements-feedback/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: requirements-feedback
-description: This skill should be used when the user asks about "feedback loops", "iterate on requirements", "continuous documentation", "refine requirements", "update requirements", "requirements changed", "stakeholder review", "validate requirements", "incorporate feedback", "gather feedback", "requirements review meeting", "backlog refinement feedback", "user research findings", "sprint retrospective feedback", or when they need guidance on collecting and incorporating feedback throughout the requirements lifecycle.
+description: This skill should be used when the user asks about "feedback loops", "iterate on requirements", "continuous documentation", "refine requirements", "update requirements", "requirements changed", "stakeholder review", "validate requirements", "incorporate feedback", "gather feedback", "requirements review meeting", "backlog refinement feedback", "user research findings", "sprint retrospective feedback", "help me gather feedback", "run a feedback session", "get input on my vision", "get input on my epics", "get input on my stories", "collect user feedback", "document feedback from meeting", "review requirements with stakeholders", or when they need guidance on collecting and incorporating feedback throughout the requirements lifecycle.
 version: 0.2.0
 ---
 


### PR DESCRIPTION
## Description

Add action-oriented trigger phrases to the requirements-feedback skill description to improve skill discovery when users phrase requests as actions rather than nouns.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to README, CLAUDE.md, or component docs)
- [ ] Refactoring (code change that neither fixes a bug nor adds a feature)
- [ ] Configuration change (changes to .markdownlint.json, plugin.json, etc.)

## Component(s) Affected

- [ ] Commands (`/re:*`)
- [x] Skills (methodology and best practices)
- [ ] Agents (requirements-assistant, requirements-validator)
- [ ] Hooks (UserPromptSubmit)
- [ ] Documentation (README.md, CLAUDE.md, SECURITY.md)
- [ ] Configuration (.markdownlint.json, plugin.json, marketplace.json)
- [ ] Issue/PR templates
- [ ] Other (please specify):

## Motivation and Context

The current skill description has mostly noun-based trigger phrases ("feedback loops", "stakeholder review"), but users often phrase requests as actions ("help me gather feedback", "run a feedback session"). This causes the skill to not trigger reliably for action-oriented user queries.

Fixes #207

## Changes Made

Added 8 action-oriented trigger phrases to the skill description:
- "help me gather feedback"
- "run a feedback session"
- "get input on my vision"
- "get input on my epics"
- "get input on my stories"
- "collect user feedback"
- "document feedback from meeting"
- "review requirements with stakeholders"

## How Has This Been Tested?

**Test Configuration**:
- Claude Code version: Latest
- GitHub CLI version: 2.x
- OS: macOS

**Test Steps**:
1. Ran `markdownlint` on the modified file - passed
2. Verified YAML frontmatter is valid
3. Verified description follows third-person format with trigger phrases

## Checklist

### General

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas (if applicable)
- [x] My changes generate no new warnings or errors

### Documentation

- [x] I have updated the documentation accordingly (README.md, CLAUDE.md, or component docs)
- [x] I have updated YAML frontmatter (if applicable)
- [x] I have verified all links work correctly

### Markdown

- [x] I have run `markdownlint` and fixed all issues
- [x] My markdown follows the repository style (ATX headers, dash lists, fenced code blocks)
- [x] I have verified special HTML elements are properly closed (`<example>`, `<commentary>`, etc.)

### Component-Specific Checks

#### Skills (if applicable)

- [x] Description uses third-person with specific trigger phrases
- [x] SKILL.md is under 2,000 words (progressive disclosure)
- [x] Detailed content is in `references/` subdirectory
- [x] Templates follow the established format

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)