### PR TITLE
docs(skill): move Command Integration section after Purpose

### DIFF
--- a/plugins/requirements-expert/skills/requirements-feedback/SKILL.md
+++ b/plugins/requirements-expert/skills/requirements-feedback/SKILL.md
@@ -37,6 +37,20 @@ Requirements evolve as teams learn more about users, technology, and the market.
 - Improves quality through iteration
 - Builds shared understanding across team and stakeholders
 
+## Command Integration
+
+This skill complements the `/re:*` commands. Use the appropriate tool for each scenario:
+
+| Scenario | Recommended Tool |
+|----------|------------------|
+| Validate structure and INVEST compliance | `/re:review` command |
+| Check project status and hierarchy | `/re:status` command |
+| Collect stakeholder feedback | This skill + `references/feedback-techniques.md` |
+| Run a feedback review meeting | This skill + `references/feedback-checklist.md` |
+| Incorporate feedback into requirements | This skill + Quick Reference workflow |
+
+**Workflow:** Run `/re:review` for automated validation, then use this skill for human feedback collection and incorporation.
+
 ## Feedback at Each Stage
 
 Each level of the requirements hierarchy has distinct feedback needs. For detailed guidance on who to involve, what questions to ask, and how to incorporate feedback at each level, see `references/stage-feedback-guide.md`.
@@ -202,20 +216,6 @@ At each transition:
 ---
 
 Requirements feedback is not a phase—it's an ongoing practice that keeps requirements aligned with reality and ensures continuous improvement throughout the product lifecycle.
-
-## Command Integration
-
-This skill complements the `/re:*` commands. Use the appropriate tool for each scenario:
-
-| Scenario | Recommended Tool |
-|----------|------------------|
-| Validate structure and INVEST compliance | `/re:review` command |
-| Check project status and hierarchy | `/re:status` command |
-| Collect stakeholder feedback | This skill + `references/feedback-techniques.md` |
-| Run a feedback review meeting | This skill + `references/feedback-checklist.md` |
-| Incorporate feedback into requirements | This skill + Quick Reference workflow |
-
-**Workflow:** Run `/re:review` for automated validation, then use this skill for human feedback collection and incorporation.
 
 ## Related Skills
 


### PR DESCRIPTION
## Summary

Move the Command Integration section from near the end of the requirements-feedback SKILL.md to immediately after the Purpose section, improving discoverability for Claude.

## Problem

The Command Integration section was buried at lines 206-218, near the end of the document after "GitHub Projects Integration". This important context about when to use `/re:*` commands vs this skill was easy to miss.

Fixes #214

## Solution

Relocated the Command Integration section to appear after the Purpose section (now lines 40-52). The new document structure is:

1. Quick Actions (routing)
2. Routing
3. Purpose
4. **Command Integration** ← Moved here
5. Feedback at Each Stage
6. ...remaining sections...
7. Related Skills

### Why This Location

This matches patterns in other skills where important context (like "When to Use This Skill") appears early. When Claude loads the skill, understanding the relationship to commands early helps with:
- Avoiding duplicate work (don't manually validate what `/re:review` checks)
- Recommending appropriate tools to users
- Understanding the skill's scope and boundaries

## Changes

- `plugins/requirements-expert/skills/requirements-feedback/SKILL.md`: Moved Command Integration section from lines 206-218 to lines 40-52

## Testing

- [x] Markdown linting passes
- [x] Section content unchanged, only location moved
- [x] Document structure follows skill patterns

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Changes are focused and minimal

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)