### PR TITLE
feat(skill): extract feedback templates to dedicated reference file

### DIFF
--- a/plugins/requirements-expert/skills/requirements-feedback/SKILL.md
+++ b/plugins/requirements-expert/skills/requirements-feedback/SKILL.md
@@ -185,6 +185,7 @@ Load references as needed:
 | **stage-feedback-guide.md** | Detailed guidance for feedback at each requirements level (Vision, Epic, Story, Task) | `references/stage-feedback-guide.md` |
 | **feedback-techniques.md** | Methods for user research, stakeholder reviews, team feedback, and automated feedback | `references/feedback-techniques.md` |
 | **feedback-checklist.md** | Conducting feedback reviews or validating requirements at any level | `references/feedback-checklist.md` |
+| **feedback-templates.md** | GitHub comment templates for documenting feedback | `references/feedback-templates.md` |
 
 ## Examples
 

--- a/plugins/requirements-expert/skills/requirements-feedback/references/feedback-checklist.md
+++ b/plugins/requirements-expert/skills/requirements-feedback/references/feedback-checklist.md
@@ -378,44 +378,14 @@ Use this checklist to ensure comprehensive feedback collection and incorporation
 
 ---
 
-## Template: Feedback Review Meeting
+## Templates
 
-**Meeting:** [Vision/Epic/Story] Feedback Review
-**Date:** [YYYY-MM-DD]
-**Attendees:** [Names and roles]
-**Duration:** [60-90 minutes]
+For GitHub comment templates to document feedback, see `feedback-templates.md`:
 
-**Agenda:**
-
-1. **Review Current State** (10 min)
-   - Present current requirements
-   - Highlight recent changes
-   - Share context
-
-2. **Collect Feedback** (30 min)
-   - Go through feedback questions for this level
-   - Capture all input (no debate yet)
-   - Use checklist above
-
-3. **Discussion** (20 min)
-   - Discuss key themes and patterns
-   - Validate or invalidate assumptions
-   - Identify areas of disagreement
-
-4. **Decisions** (15 min)
-   - Determine what changes to make
-   - Assign action items
-   - Set next review date
-
-5. **Wrap-up** (5 min)
-   - Summarize decisions
-   - Confirm action items and owners
-   - Thank participants
-
-**Follow-up:**
-- [ ] Update GitHub issues within 48 hours - in GitHub Projects
-- [ ] Communicate changes to broader team
-- [ ] Schedule next review
+- **Feedback Collection Template** - Document feedback received from stakeholders
+- **Feedback Incorporated Template** - Communicate how feedback was addressed
+- **Feedback Rejection Template** - Explain when feedback cannot be incorporated
+- **Feedback Review Meeting Template** - Structure feedback review meetings
 
 ---
 

--- a/plugins/requirements-expert/skills/requirements-feedback/references/feedback-templates.md
+++ b/plugins/requirements-expert/skills/requirements-feedback/references/feedback-templates.md
@@ -1,0 +1,155 @@
+# Feedback Templates
+
+Ready-to-use GitHub comment templates for documenting feedback throughout the requirements lifecycle.
+
+---
+
+## Feedback Collection Template
+
+Use this template when documenting feedback received from stakeholders, users, or team members.
+
+```markdown
+## [Level] Feedback - [Type] (YYYY-MM-DD)
+
+**Participants:** [Names and roles]
+**Facilitator:** [Name]
+
+### Key Feedback Themes
+
+#### 1. [Theme Name] ([Source])
+- [Specific feedback point]
+- [Specific feedback point]
+- **Impact:** [High/Medium/Low] - [Brief explanation]
+
+### Decisions Needed
+
+- [ ] [Decision item 1]
+- [ ] [Decision item 2]
+
+### Next Steps
+
+1. [Action item]
+2. [Action item]
+
+cc: @[stakeholder1] @[stakeholder2]
+```
+
+---
+
+## Feedback Incorporated Template
+
+Use this template when communicating how feedback was addressed.
+
+```markdown
+## [Level] Updated - Feedback Incorporated (YYYY-MM-DD)
+
+Thank you for the valuable feedback! Here's how it was incorporated:
+
+### Changes Made
+
+**[Section 1]:**
+- [Change description]
+
+**[Section 2]:**
+- [Change description]
+
+### Deferred Decisions
+
+- **[Item]:** [Reason for deferral, when it will be revisited]
+
+### What's Next
+
+1. [Next step]
+2. [Next step]
+
+cc: @[stakeholder1] @[stakeholder2]
+```
+
+---
+
+## Feedback Rejection Template
+
+Use this template when feedback cannot be incorporated, with clear rationale.
+
+```markdown
+## Feedback Response - [Item] (YYYY-MM-DD)
+
+Thank you for the suggestion about [topic].
+
+**Decision:** Not incorporated at this time
+
+**Rationale:**
+- [Reason 1]
+- [Reason 2]
+
+**Alternative approach:**
+[If applicable, what we're doing instead]
+
+**Revisit:**
+[When/if this will be reconsidered]
+
+Happy to discuss further if you have questions.
+
+cc: @[feedback-provider]
+```
+
+---
+
+## Feedback Review Meeting Template
+
+Use this template to structure and document feedback review meetings.
+
+**Meeting:** [Vision/Epic/Story] Feedback Review
+**Date:** [YYYY-MM-DD]
+**Attendees:** [Names and roles]
+**Duration:** [60-90 minutes]
+
+**Agenda:**
+
+1. **Review Current State** (10 min)
+   - Present current requirements
+   - Highlight recent changes
+   - Share context
+
+2. **Collect Feedback** (30 min)
+   - Go through feedback questions for this level
+   - Capture all input (no debate yet)
+   - Use checklist from `feedback-checklist.md`
+
+3. **Discussion** (20 min)
+   - Discuss key themes and patterns
+   - Validate or invalidate assumptions
+   - Identify areas of disagreement
+
+4. **Decisions** (15 min)
+   - Determine what changes to make
+   - Assign action items
+   - Set next review date
+
+5. **Wrap-up** (5 min)
+   - Summarize decisions
+   - Confirm action items and owners
+   - Thank participants
+
+**Follow-up:**
+
+- [ ] Update GitHub issues within 48 hours - in GitHub Projects
+- [ ] Communicate changes to broader team
+- [ ] Schedule next review
+
+---
+
+## Usage Tips
+
+- **Be consistent:** Use the same template format across all feedback documentation
+- **Tag stakeholders:** Always cc relevant people so they receive notifications
+- **Include dates:** Timestamps help track the evolution of requirements
+- **Link to evidence:** Reference user quotes, data, or research that supports feedback
+- **Close the loop:** Always follow up with feedback providers about how their input was used
+
+## Related Resources
+
+- `feedback-checklist.md` - Checklists for conducting feedback reviews at each level
+- `feedback-techniques.md` - Methods for collecting feedback from various sources
+- `stage-feedback-guide.md` - Detailed guidance for feedback at each requirements level
+- `../examples/feedback-workflow-example.md` - Complete example of feedback workflow in action


### PR DESCRIPTION
## Description

Create a dedicated `feedback-templates.md` reference file to centralize all GitHub comment templates for the requirements-feedback skill. This improves discoverability and reduces cognitive load in the checklist file.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to README, CLAUDE.md, or component docs)
- [ ] Refactoring (code change that neither fixes a bug nor adds a feature)
- [ ] Configuration change (changes to .markdownlint.json, plugin.json, etc.)

## Component(s) Affected

- [ ] Commands (`/re:*`)
- [x] Skills (methodology and best practices)
- [ ] Agents (requirements-assistant, requirements-validator)
- [ ] Hooks (UserPromptSubmit)
- [ ] Documentation (README.md, CLAUDE.md, SECURITY.md)
- [ ] Configuration (.markdownlint.json, plugin.json, marketplace.json)
- [ ] Issue/PR templates
- [ ] Other (please specify):

## Motivation and Context

The `feedback-checklist.md` file contained a Meeting Template that was harder to find among the extensive checklists. Users looking specifically for templates had to scroll through the entire checklist file.

This PR:
1. Creates `references/feedback-templates.md` with all 4 feedback templates
2. Replaces the Meeting Template in `feedback-checklist.md` with a reference section
3. Adds the new file to the SKILL.md reference table

**Note:** The issue description mentioned templates at incorrect line numbers. After analysis, I found:
- `feedback-checklist.md` had only 1 template (Meeting Template at lines 381-418)
- `feedback-workflow-example.md` has 3 templates (Collection, Incorporated, Rejection) but these should remain there as they're integral to demonstrating a complete workflow

This PR consolidates all templates into the new reference file for easy discovery, while leaving the example file's templates in context.

Fixes #215

## How Has This Been Tested?

**Test Configuration**:
- Markdownlint validation passed
- File structure verified

**Test Steps**:
1. Created new `feedback-templates.md` with all 4 templates
2. Updated `feedback-checklist.md` to reference new file
3. Updated SKILL.md reference table
4. Ran `markdownlint` - all files pass

## Checklist

### General

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas (if applicable)
- [x] My changes generate no new warnings or errors

### Documentation

- [x] I have updated the documentation accordingly (README.md, CLAUDE.md, or component docs)
- [x] I have updated YAML frontmatter (if applicable)
- [x] I have verified all links work correctly

### Markdown

- [x] I have run `markdownlint` and fixed all issues
- [x] My markdown follows the repository style (ATX headers, dash lists, fenced code blocks)
- [x] I have verified special HTML elements are properly closed (`<example>`, `<commentary>`, etc.)

### Component-Specific Checks

#### Skills (if applicable)

- [x] Description uses third-person with specific trigger phrases
- [x] SKILL.md is under 2,000 words (progressive disclosure)
- [x] Detailed content is in `references/` subdirectory
- [x] Templates follow the established format

## Additional Notes

**File size impact:**
- `feedback-checklist.md`: 423 → 392 lines (-31 lines)
- `feedback-templates.md`: 155 lines (new file)

The new templates file includes:
- Feedback Collection Template
- Feedback Incorporated Template
- Feedback Rejection Template
- Feedback Review Meeting Template
- Usage tips and related resources section

## Reviewer Notes

**Areas that need special attention**:
- Verify the Templates section reference in `feedback-checklist.md` is clear
- Confirm all 4 templates are complete and properly formatted

**Known limitations or trade-offs**:
- The example file (`feedback-workflow-example.md`) still contains template examples in context, which is intentional - examples show templates being used in a real workflow

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)