### PR TITLE
fix(skill): remove duplicated templates from feedback workflow example

### DIFF
--- a/plugins/requirements-expert/skills/requirements-feedback/examples/feedback-workflow-example.md
+++ b/plugins/requirements-expert/skills/requirements-feedback/examples/feedback-workflow-example.md
@@ -267,86 +267,14 @@ cc: @sarah-chen @marcus-johnson @emily-rodriguez @david-kim
 
 ## GitHub Comment Templates
 
-Use these templates for consistent feedback documentation:
+For ready-to-use templates for documenting feedback, see `references/feedback-templates.md`:
 
-### Feedback Collection Template
+- **Feedback Collection Template** - Document feedback received from stakeholders
+- **Feedback Incorporated Template** - Communicate how feedback was addressed
+- **Feedback Rejection Template** - Explain when feedback cannot be incorporated
+- **Feedback Review Meeting Template** - Structure feedback review sessions
 
-```markdown
-## [Level] Feedback - [Type] (YYYY-MM-DD)
-
-**Participants:** [Names and roles]
-**Facilitator:** [Name]
-
-### Key Feedback Themes
-
-#### 1. [Theme Name] ([Source])
-- [Specific feedback point]
-- [Specific feedback point]
-- **Impact:** [High/Medium/Low] - [Brief explanation]
-
-### Decisions Needed
-
-- [ ] [Decision item 1]
-- [ ] [Decision item 2]
-
-### Next Steps
-
-1. [Action item]
-2. [Action item]
-
-cc: @[stakeholder1] @[stakeholder2]
-```
-
-### Feedback Incorporated Template
-
-```markdown
-## [Level] Updated - Feedback Incorporated (YYYY-MM-DD)
-
-Thank you for the valuable feedback! Here's how it was incorporated:
-
-### Changes Made
-
-**[Section 1]:**
-- [Change description]
-
-**[Section 2]:**
-- [Change description]
-
-### Deferred Decisions
-
-- **[Item]:** [Reason for deferral, when it will be revisited]
-
-### What's Next
-
-1. [Next step]
-2. [Next step]
-
-cc: @[stakeholder1] @[stakeholder2]
-```
-
-### Feedback Rejection Template
-
-```markdown
-## Feedback Response - [Item] (YYYY-MM-DD)
-
-Thank you for the suggestion about [topic].
-
-**Decision:** Not incorporated at this time
-
-**Rationale:**
-- [Reason 1]
-- [Reason 2]
-
-**Alternative approach:**
-[If applicable, what we're doing instead]
-
-**Revisit:**
-[When/if this will be reconsidered]
-
-Happy to discuss further if you have questions.
-
-cc: @[feedback-provider]
-```
+The example above uses these templates in Step 3 (documenting feedback) and Step 6 (communicating changes).
 
 ---
 


### PR DESCRIPTION
## Summary

Removes ~80 lines of duplicated GitHub comment templates from the feedback workflow example, replacing them with a reference to the authoritative source file.

## Problem

The `examples/feedback-workflow-example.md` file contained duplicated content from `references/feedback-templates.md`, violating progressive disclosure principles documented in skill development best practices.

Fixes #219

## Solution

Replaced the inline templates (lines 267-350) with a concise reference section that:
- Points to `references/feedback-templates.md` as the single source of truth
- Lists all four available templates with brief descriptions
- Notes where the example uses these templates (Steps 3 and 6)

### Alternatives Considered

1. **Keep templates in example, remove from references** - Rejected because references is the proper location for reusable templates per progressive disclosure
2. **Keep duplicates** - Rejected because this creates maintenance burden and violates DRY principles

## Changes

- `examples/feedback-workflow-example.md`: Removed 78 lines of duplicated templates, added 6-line reference section

## Testing

- [x] Markdown linting passes
- [x] Links in replacement section are valid relative paths
- [x] Example still flows logically with reference instead of inline templates

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Changes are focused and minimal

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)