### PR TITLE
feat(skill): enhance Related Skills section with actionable routing guidance

### DIFF
--- a/plugins/requirements-expert/skills/requirements-feedback/SKILL.md
+++ b/plugins/requirements-expert/skills/requirements-feedback/SKILL.md
@@ -196,10 +196,12 @@ Requirements feedback is not a phase—it's an ongoing practice that keeps requi
 
 ## Related Skills
 
-| Skill | Relationship |
-|-------|-------------|
-| **vision-discovery** | Gather feedback to validate and refine vision |
-| **epic-identification** | Gather feedback to validate epic completeness and scope |
-| **user-story-creation** | Gather feedback to validate story value and acceptance criteria |
-| **task-breakdown** | Gather implementation feedback to refine tasks |
-| **prioritization** | Use feedback insights to adjust priorities |
+Load these skills when chaining between requirements stages:
+
+| When working on... | Also consider loading... |
+|--------------------|--------------------------|
+| Vision feedback | `vision-discovery` - for comprehensive vision creation guidance |
+| Epic feedback | `epic-identification` - for epic scoping and dependency mapping |
+| Story feedback | `user-story-creation` - for INVEST criteria and acceptance criteria |
+| Task feedback | `task-breakdown` - for implementation layer organization |
+| Priority changes from feedback | `prioritization` - for MoSCoW framework application |


### PR DESCRIPTION
## Summary

Replaces descriptive skill relationships with action-oriented routing table that tells Claude WHEN to load complementary skills during feedback workflows.

## Problem

The Related Skills section listed skills with descriptions of their relationship to feedback, but didn't provide actionable routing guidance for Claude.

Fixes #222

## Solution

Changed the table format from "Skill | Relationship" to "When working on... | Also consider loading..." with specific use cases:

| When working on... | Also consider loading... |
|--------------------|--------------------------|
| Vision feedback | `vision-discovery` - for comprehensive vision creation guidance |
| Epic feedback | `epic-identification` - for epic scoping and dependency mapping |
| Story feedback | `user-story-creation` - for INVEST criteria and acceptance criteria |
| Task feedback | `task-breakdown` - for implementation layer organization |
| Priority changes from feedback | `prioritization` - for MoSCoW framework application |

### Alternatives Considered

1. **Remove section entirely**: Would lose valuable cross-skill navigation
2. **Keep as-is with minor rewording**: Wouldn't address the core issue of actionable routing

## Changes

- Updated Related Skills section in `plugins/requirements-expert/skills/requirements-feedback/SKILL.md`
- Added introductory text explaining the purpose of the table
- Changed column headers to action-oriented format

## Testing

- [x] Linting passes
- [x] Content follows skill best practices

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Changes are focused and minimal

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)