### PR TITLE
feat(skill): add explicit routing triggers to Related Skills table

### DIFF
--- a/plugins/requirements-expert/skills/requirements-feedback/SKILL.md
+++ b/plugins/requirements-expert/skills/requirements-feedback/SKILL.md
@@ -166,12 +166,12 @@ Working examples that can be copied and adapted:
 
 ## Related Skills
 
-Load these skills when chaining between requirements stages:
+Load these skills when feedback reveals needs beyond this skill's scope:
 
-| When working on... | Also consider loading... |
-|--------------------|--------------------------|
-| Vision feedback | `vision-discovery` - for comprehensive vision creation guidance |
-| Epic feedback | `epic-identification` - for epic scoping and dependency mapping |
-| Story feedback | `user-story-creation` - for INVEST criteria and acceptance criteria |
-| Task feedback | `task-breakdown` - for implementation layer organization |
-| Priority changes from feedback | `prioritization` - for MoSCoW framework application |
+| Feedback Context | Load Skill | Routing Trigger |
+|------------------|------------|-----------------|
+| Vision feedback reveals gaps in vision definition | `vision-discovery` | User needs to revise or create vision elements |
+| Epic feedback reveals scoping issues | `epic-identification` | User needs to adjust epic boundaries or dependencies |
+| Story feedback reveals INVEST violations | `user-story-creation` | User needs to rewrite stories to meet criteria |
+| Task feedback reveals breakdown issues | `task-breakdown` | User needs to reorganize task structure |
+| Feedback changes priorities | `prioritization` | User needs to re-apply MoSCoW framework |


### PR DESCRIPTION
## Description

Enhances the Related Skills section in `requirements-feedback` SKILL.md with a more actionable 3-column table format that provides explicit routing guidance for Claude.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to README, CLAUDE.md, or component docs)
- [ ] Refactoring (code change that neither fixes a bug nor adds a feature)
- [ ] Configuration change (changes to .markdownlint.json, plugin.json, etc.)

## Component(s) Affected

- [ ] Commands (`/re:*`)
- [x] Skills (methodology and best practices)
- [ ] Agents (requirements-assistant, requirements-validator)
- [ ] Hooks (UserPromptSubmit)
- [ ] Documentation (README.md, CLAUDE.md, SECURITY.md)
- [ ] Configuration (.markdownlint.json, plugin.json, marketplace.json)
- [ ] Issue/PR templates
- [ ] Other (please specify):

## Motivation and Context

The current Related Skills table tells Claude what to load but not explicitly when/why to load it during a feedback workflow. The routing trigger is implicit rather than explicit.

The new format provides:
- **Feedback Context**: What the feedback reveals (e.g., "Vision feedback reveals gaps in vision definition")
- **Load Skill**: Which skill to load
- **Routing Trigger**: Explicit condition when to chain (e.g., "User needs to revise or create vision elements")

This makes the trigger condition explicit, helping Claude know when to chain to another skill.

Fixes #230

## How Has This Been Tested?

**Test Configuration**:
- Claude Code version: Claude Opus 4.5
- GitHub CLI version: 2.x
- OS: macOS Darwin 25.1.0
- Testing repository: sjnims/requirements-expert

**Test Steps**:
1. Verified markdown formatting with `markdownlint`
2. Reviewed diff to ensure table structure is correct
3. Confirmed no content loss during transformation

## Checklist

### General

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas (if applicable)
- [x] My changes generate no new warnings or errors

### Documentation

- [x] I have updated the documentation accordingly (README.md, CLAUDE.md, or component docs)
- [x] I have updated YAML frontmatter (if applicable)
- [x] I have verified all links work correctly

### Markdown

- [x] I have run `markdownlint` and fixed all issues
- [x] My markdown follows the repository style (ATX headers, dash lists, fenced code blocks)
- [x] I have verified special HTML elements are properly closed (`<example>`, `<commentary>`, etc.)

### Component-Specific Checks

#### Skills (if applicable)

- [x] Description uses third-person with specific trigger phrases
- [x] SKILL.md is under 2,000 words (progressive disclosure)
- [x] Detailed content is in `references/` subdirectory
- [x] Templates follow the established format

### Testing

- [x] I have tested the plugin locally with `cc --plugin-dir plugins/requirements-expert`
- [ ] I have tested the full workflow (if applicable)
- [ ] I have verified GitHub CLI integration works (if applicable)
- [ ] I have tested in a clean repository (not my development repo)

### Version Management (if applicable)

- [x] N/A - Not a release

## Additional Notes

This is a low-priority polish item that improves Claude's ability to chain between skills during feedback workflows. The key insight is that skills work best when they provide explicit routing guidance: "Load X when Y happens" is more actionable than "Consider loading X."

## Reviewer Notes

**Areas that need special attention**:
- Verify the new table format is clear and actionable
- Confirm routing triggers are specific enough to be useful

**Known limitations or trade-offs**:
- The new format differs from other skills' Related Skills sections (which use a 2-column Skill/Relationship format). This is intentional because requirements-feedback is a cross-cutting concern that applies to all other skills, so having more explicit routing guidance is justified.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)