### PR TITLE
feat(skill): add Command Integration section to 5 skills

### DIFF
--- a/plugins/requirements-expert/skills/epic-identification/SKILL.md
+++ b/plugins/requirements-expert/skills/epic-identification/SKILL.md
@@ -18,6 +18,10 @@ version: 0.2.0
 | Creating epic issues | Use template | `references/epic-template.md` |
 | Viewing examples | Load sample epic set | `examples/example-epic-set.md` |
 
+## Command Integration
+
+The `/re:identify-epics` command guides epic creation in GitHub Projects. This skill provides the methodology for identifying and defining epics—including discovery techniques (user journey mapping, capability decomposition), validation criteria, and common patterns. Load this skill for technique guidance beyond what the command provides.
+
 ## Overview
 
 Systematically decompose a product vision into well-defined epics—major capabilities or features that can be further broken down into user stories and tasks. Epics represent significant bodies of work that are too large for a single iteration but directly contribute to achieving the vision.

--- a/plugins/requirements-expert/skills/prioritization/SKILL.md
+++ b/plugins/requirements-expert/skills/prioritization/SKILL.md
@@ -17,6 +17,10 @@ version: 0.2.0
 | Step-by-step workflow | Load complete worksheet | `references/moscow-worksheet.md` |
 | Viewing examples | Load prioritization session | `examples/example-prioritization-session.md` |
 
+## Command Integration
+
+The `/re:prioritize` command applies MoSCoW priorities to requirements in GitHub Projects. This skill provides the MoSCoW framework, decision criteria, and prioritization worksheets that the command uses. Load this skill for deeper understanding of prioritization concepts or when you need guidance beyond what the command provides.
+
 ## Overview
 
 Prioritization is the process of determining the relative importance and sequence of requirements at any level—epics, user stories, or tasks. Using the MoSCoW framework (Must Have, Should Have, Could Have, Won't Have), teams can make informed decisions about what to build first, ensuring maximum value delivery within constraints.

--- a/plugins/requirements-expert/skills/task-breakdown/SKILL.md
+++ b/plugins/requirements-expert/skills/task-breakdown/SKILL.md
@@ -17,6 +17,10 @@ version: 0.2.0
 | Creating task issues | Use template | `references/task-template.md` |
 | Viewing examples | Load sample task set | `examples/example-task-set.md` |
 
+## Command Integration
+
+The `/re:create-tasks` command guides task creation in GitHub Projects. This skill provides the methodology for breaking down stories into tasks—including task patterns, acceptance criteria templates, and layer-by-layer decomposition techniques. Load this skill for deeper understanding of task breakdown concepts or when you need guidance beyond what the command provides.
+
 ## Overview
 
 Task breakdown transforms user stories into concrete, executable work items that can be assigned, tracked, and completed. Tasks represent the actual implementation steps needed to deliver a user story, each with clear acceptance criteria. This skill guides the process of decomposing stories into well-defined tasks suitable for GitHub issue tracking.

--- a/plugins/requirements-expert/skills/user-story-creation/SKILL.md
+++ b/plugins/requirements-expert/skills/user-story-creation/SKILL.md
@@ -17,6 +17,10 @@ version: 0.2.0
 | Creating story issues | Use template | `references/story-template.md` |
 | Viewing examples | Load sample story set | `examples/example-story-set.md` |
 
+## Command Integration
+
+The `/re:create-stories` command guides user story creation in GitHub Projects. This skill provides the methodology for writing effective stories—including INVEST criteria validation and splitting techniques for oversized stories. Load this skill for deeper understanding of story creation concepts or when you need guidance beyond what the command provides.
+
 ## Overview
 
 User story creation transforms epics into specific, actionable requirements that describe functionality from a user's perspective. Well-written user stories follow the INVEST criteria and provide clear value while remaining small enough to be completed in a single iteration. This skill guides the process of breaking down epics into high-quality user stories.

--- a/plugins/requirements-expert/skills/vision-discovery/SKILL.md
+++ b/plugins/requirements-expert/skills/vision-discovery/SKILL.md
@@ -17,6 +17,10 @@ version: 0.2.0
 | Documenting vision | Use template | `references/vision-template.md` |
 | Viewing example | Load sample | `examples/sample-vision.md` |
 
+## Command Integration
+
+The `/re:discover-vision` command orchestrates the vision creation workflow. This skill provides the methodology, templates, and techniques (like 5 Whys) that the command uses. Load this skill for deeper understanding of vision discovery concepts or when you need guidance beyond what the command provides.
+
 ## Overview
 
 Vision discovery is the critical first step in the requirements lifecycle. A clear, well-articulated product vision provides direction for all subsequent work—epics, user stories, and tasks all flow from and align with the vision. This skill guides the process of discovering and documenting a compelling product vision through structured questioning and best practices.


### PR DESCRIPTION
## Summary

- Add "Command Integration" section to 5 skills explaining relationship to `/re:*` commands
- Helps Claude understand when to suggest a command vs. when to load skill knowledge
- Follows the existing pattern established in `requirements-feedback` skill

Fixes #239

## Changes

Each skill now has a brief "Command Integration" section placed after "Quick Actions & Routing":

| Skill | Related Command |
|-------|-----------------|
| `vision-discovery` | `/re:discover-vision` |
| `epic-identification` | `/re:identify-epics` |
| `user-story-creation` | `/re:create-stories` |
| `task-breakdown` | `/re:create-tasks` |
| `prioritization` | `/re:prioritize` |

## Test plan

- [x] Markdownlint passes on all modified files
- [x] Section placement matches `requirements-feedback` skill structure
- [x] Content describes command/skill relationship accurately

🤖 Generated with [Claude Code](https://claude.com/claude-code)