### PR TITLE
feat(skill): add explicit routing triggers to Related Skills table

### DIFF
--- a/plugins/requirements-expert/skills/epic-identification/SKILL.md
+++ b/plugins/requirements-expert/skills/epic-identification/SKILL.md
@@ -367,9 +367,11 @@ Epics provide the roadmap from vision to execution—invest time to identify the
 
 ## Related Skills
 
-| Skill | Relationship |
-|-------|-------------|
-| **vision-discovery** | Prerequisite—vision must exist before identifying epics |
-| **user-story-creation** | Next step—break epics into user stories |
-| **prioritization** | Use to apply MoSCoW framework to epic priorities |
-| **requirements-feedback** | Use to validate epics with stakeholders |
+Load these skills when epic work reveals needs beyond this skill's scope:
+
+| Epic Context | Load Skill | Routing Trigger |
+|--------------|------------|-----------------|
+| No vision exists or vision needs revision | `vision-discovery` | User needs to create or refine the product vision |
+| Epics are complete and user wants stories | `user-story-creation` | User is ready to break an epic into user stories |
+| Epic priorities need to be established | `prioritization` | User needs to apply MoSCoW framework to epics |
+| Epics need stakeholder validation | `requirements-feedback` | User needs to gather input on epic scope or priorities |

--- a/plugins/requirements-expert/skills/prioritization/SKILL.md
+++ b/plugins/requirements-expert/skills/prioritization/SKILL.md
@@ -359,9 +359,11 @@ Prioritization is an ongoing activity throughout the requirements lifecycle—us
 
 ## Related Skills
 
-| Skill | Relationship |
-|-------|-------------|
-| **epic-identification** | Apply prioritization after identifying epics |
-| **user-story-creation** | Apply prioritization after creating stories |
-| **task-breakdown** | Apply prioritization after breaking down tasks |
-| **requirements-feedback** | Use feedback to inform priority adjustments |
+Load these skills when prioritization reveals needs beyond this skill's scope:
+
+| Prioritization Context | Load Skill | Routing Trigger |
+|------------------------|------------|-----------------|
+| Epics need identification or refinement | `epic-identification` | User needs to create or adjust epic scope |
+| Stories need creation or refinement | `user-story-creation` | User needs to create or adjust user stories |
+| Tasks need breakdown or refinement | `task-breakdown` | User needs to create or adjust tasks |
+| Priorities need validation with stakeholders | `requirements-feedback` | User needs to gather feedback on priority decisions |

--- a/plugins/requirements-expert/skills/task-breakdown/SKILL.md
+++ b/plugins/requirements-expert/skills/task-breakdown/SKILL.md
@@ -382,8 +382,10 @@ Tasks are where vision becomes reality—invest time to make them clear, testabl
 
 ## Related Skills
 
-| Skill | Relationship |
-|-------|-------------|
-| **user-story-creation** | Prerequisite—create stories before breaking down into tasks |
-| **prioritization** | Use after task creation to apply MoSCoW priorities |
-| **requirements-feedback** | Use to gather implementation feedback and refine requirements |
+Load these skills when task work reveals needs beyond this skill's scope:
+
+| Task Context | Load Skill | Routing Trigger |
+|--------------|------------|-----------------|
+| No stories exist or story is unclear | `user-story-creation` | User needs to create or refine user stories |
+| Task priorities need to be established | `prioritization` | User needs to apply MoSCoW framework to tasks |
+| Tasks reveal implementation issues | `requirements-feedback` | User needs to gather feedback or refine requirements |

--- a/plugins/requirements-expert/skills/user-story-creation/SKILL.md
+++ b/plugins/requirements-expert/skills/user-story-creation/SKILL.md
@@ -348,9 +348,11 @@ User stories bridge epics and executable work. Invest time to make them clear, v
 
 ## Related Skills
 
-| Skill | Relationship |
-|-------|-------------|
-| **epic-identification** | Prerequisite—epics must exist before creating stories |
-| **task-breakdown** | Next step—break stories into implementable tasks |
-| **prioritization** | Use to apply MoSCoW framework to story priorities |
-| **requirements-feedback** | Use to validate stories with users and stakeholders |
+Load these skills when story work reveals needs beyond this skill's scope:
+
+| Story Context | Load Skill | Routing Trigger |
+|---------------|------------|-----------------|
+| No epics exist or epic scope is unclear | `epic-identification` | User needs to create or refine epics |
+| Stories are complete and user wants tasks | `task-breakdown` | User is ready to break a story into implementation tasks |
+| Story priorities need to be established | `prioritization` | User needs to apply MoSCoW framework to stories |
+| Stories need user or stakeholder validation | `requirements-feedback` | User needs to gather input on story scope or acceptance criteria |

--- a/plugins/requirements-expert/skills/vision-discovery/SKILL.md
+++ b/plugins/requirements-expert/skills/vision-discovery/SKILL.md
@@ -302,7 +302,9 @@ The vision is the foundation—invest time to get it right before moving to epic
 
 ## Related Skills
 
-| Skill | Relationship |
-|-------|-------------|
-| **epic-identification** | Next step—break vision into major capabilities (epics) |
-| **requirements-feedback** | Use to validate vision with stakeholders and users |
+Load these skills when vision work reveals needs beyond this skill's scope:
+
+| Vision Context | Load Skill | Routing Trigger |
+|----------------|------------|-----------------|
+| Vision is complete and user wants to break it down | `epic-identification` | User is ready to identify major capabilities from vision |
+| Vision needs stakeholder validation | `requirements-feedback` | User needs to gather input on vision elements |


### PR DESCRIPTION
## Description

Transform 2-column Related Skills tables to 3-column format with explicit routing triggers, following the pattern established in `requirements-feedback`. This provides Claude with clear decision criteria for when to suggest or load each related skill.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to README, CLAUDE.md, or component docs)
- [ ] Refactoring (code change that neither fixes a bug nor adds a feature)
- [ ] Configuration change (changes to .markdownlint.json, plugin.json, etc.)

## Component(s) Affected

- [ ] Commands (`/re:*`)
- [x] Skills (methodology and best practices)
- [ ] Agents (requirements-assistant, requirements-validator)
- [ ] Hooks (UserPromptSubmit)
- [ ] Documentation (README.md, CLAUDE.md, SECURITY.md)
- [ ] Configuration (.markdownlint.json, plugin.json, marketplace.json)
- [ ] Issue/PR templates
- [ ] Other (please specify):

## Motivation and Context

The existing Related Skills tables used a simple 2-column format (Skill | Relationship) that described relationships but didn't provide explicit guidance on WHEN to route to each skill. The `requirements-feedback` skill already had a better 3-column pattern that includes:

1. **Context column** - Describes WHEN routing is needed
2. **Load Skill column** - Names the target skill
3. **Routing Trigger column** - Provides explicit decision criteria

This change brings all 5 other skills up to the same standard.

Fixes #236

## How Has This Been Tested?

**Test Configuration**:
- Claude Code version: Latest
- GitHub CLI version: 2.x
- OS: macOS
- Testing repository: N/A (markdown changes only)

**Test Steps**:
1. Verified markdown linting passes: `markdownlint plugins/requirements-expert/skills/*/SKILL.md`
2. Reviewed each updated table for consistency with requirements-feedback pattern
3. Confirmed all 5 skills now have consistent 3-column Related Skills tables

## Checklist

### General

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas (if applicable)
- [x] My changes generate no new warnings or errors

### Documentation

- [x] I have updated the documentation accordingly (README.md, CLAUDE.md, or component docs)
- [x] I have updated YAML frontmatter (if applicable)
- [x] I have verified all links work correctly

### Markdown

- [x] I have run `markdownlint` and fixed all issues
- [x] My markdown follows the repository style (ATX headers, dash lists, fenced code blocks)
- [x] I have verified special HTML elements are properly closed (`<example>`, `<commentary>`, etc.)

### Component-Specific Checks

#### Skills (if applicable)

- [x] Description uses third-person with specific trigger phrases
- [x] SKILL.md is under 2,000 words (progressive disclosure)
- [x] Detailed content is in `references/` subdirectory
- [x] Templates follow the established format

### Testing

- [x] I have tested the plugin locally with `cc --plugin-dir plugins/requirements-expert`
- [x] I have tested the full workflow (if applicable)
- [ ] I have verified GitHub CLI integration works (if applicable)
- [ ] I have tested in a clean repository (not my development repo)

### Version Management (if applicable)

- [ ] I have updated version numbers in both `plugin.json` and `marketplace.json` (if this is a release)
- [ ] I have updated version numbers in all 6 skills (if this is a release):
- [ ] I have updated CHANGELOG.md with relevant changes

## Additional Notes

**Changes by skill:**

| Skill | New Table Header |
|-------|-----------------|
| vision-discovery | Vision Context \| Load Skill \| Routing Trigger |
| epic-identification | Epic Context \| Load Skill \| Routing Trigger |
| user-story-creation | Story Context \| Load Skill \| Routing Trigger |
| task-breakdown | Task Context \| Load Skill \| Routing Trigger |
| prioritization | Prioritization Context \| Load Skill \| Routing Trigger |

Each table now includes an intro sentence: "Load these skills when [X] work reveals needs beyond this skill's scope:"

## Reviewer Notes

**Areas that need special attention**:
- Verify routing triggers are clear and actionable
- Check that context descriptions align with actual use cases

**Known limitations or trade-offs**:
- None identified

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)