### PR TITLE
docs(skill): standardize Examples table format in prioritization skill

### DIFF
--- a/plugins/requirements-expert/skills/prioritization/SKILL.md
+++ b/plugins/requirements-expert/skills/prioritization/SKILL.md
@@ -336,10 +336,10 @@ Load references as needed:
 
 Review examples for concrete patterns:
 
-| Example | What It Shows | Path |
-|---------|---------------|------|
-| **example-prioritized-backlog.md** | Load when needing output format reference for backlog structure, rationale documentation, or GitHub integration | `examples/example-prioritized-backlog.md` |
-| **example-prioritization-session.md** | Load when facilitating stakeholder sessions or needing trade-off discussion patterns | `examples/example-prioritization-session.md` |
+| Example | Use Case | Path |
+|---------|----------|------|
+| **example-prioritized-backlog.md** | Viewing backlog structure, rationale documentation, or GitHub integration format | `examples/example-prioritized-backlog.md` |
+| **example-prioritization-session.md** | Facilitating stakeholder sessions or trade-off discussions | `examples/example-prioritization-session.md` |
 
 ## Integration with Requirements Lifecycle
 


### PR DESCRIPTION
## Summary

Standardizes the Examples table header in the prioritization skill to match the format used by all other skills.

## Problem

The prioritization skill used "What It Shows" as the second column header, while all other skills use "Use Case". This created an inconsistency across the plugin.

Fixes #240

## Solution

Changed the header from `| Example | What It Shows | Path |` to `| Example | Use Case | Path |` and shortened the use case descriptions to follow the verb-noun style used by other skills:

- "Load when needing output format reference..." → "Viewing backlog structure..."
- "Load when facilitating stakeholder sessions..." → "Facilitating stakeholder sessions..."

## Changes

- `plugins/requirements-expert/skills/prioritization/SKILL.md`: Updated Examples table header and descriptions

## Verification

- [x] Markdownlint passes
- [x] All 6 skills now use identical column headers

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)