### PR TITLE
docs(skill): add Overview section to requirements-feedback skill

### DIFF
--- a/plugins/requirements-expert/skills/requirements-feedback/SKILL.md
+++ b/plugins/requirements-expert/skills/requirements-feedback/SKILL.md
@@ -20,6 +20,10 @@ version: 0.2.0
 
 The `/re:review` and `/re:status` commands handle automated validation. This skill complements them with human feedback collection and incorporation workflows.
 
+## Overview
+
+Requirements feedback is the systematic process of gathering, analyzing, and incorporating input from users, stakeholders, and team members throughout the requirements lifecycle. Unlike static documentation, requirements in GitHub Projects are living documents that evolve as understanding deepens. This skill guides the collection and integration of feedback to continuously refine vision, epics, user stories, and tasks—ensuring requirements stay aligned with real-world needs and learnings.
+
 ## Feedback at Each Stage
 
 Each level of the requirements hierarchy has distinct feedback needs. For detailed guidance on who to involve, what questions to ask, and how to incorporate feedback at each level, see `references/stage-feedback-guide.md`.


### PR DESCRIPTION
## Description

Add missing Overview section to the requirements-feedback skill to match the structure of all other skills in the plugin. The requirements-feedback skill was the only one missing this section, as identified in issue #249.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update (improvements to README, CLAUDE.md, or component docs)
- [ ] Refactoring (code change that neither fixes a bug nor adds a feature)
- [ ] Configuration change (changes to .markdownlint.json, plugin.json, etc.)

## Component(s) Affected

- [ ] Commands (`/re:*`)
- [x] Skills (methodology and best practices)
- [ ] Agents (requirements-assistant, requirements-validator)
- [ ] Hooks (UserPromptSubmit)
- [ ] Documentation (README.md, CLAUDE.md, SECURITY.md)
- [ ] Configuration (.markdownlint.json, plugin.json, marketplace.json)
- [ ] Issue/PR templates
- [ ] Other (please specify):

## Motivation and Context

The requirements-feedback skill was missing an Overview section that all other 5 skills have. This creates inconsistency in the plugin's skill structure and leaves out important context about what requirements feedback is.

**Current structure comparison:**
- ✅ vision-discovery: Has Overview section
- ✅ epic-identification: Has Overview section
- ✅ user-story-creation: Has Overview section
- ✅ task-breakdown: Has Overview section
- ✅ prioritization: Has Overview section
- ❌ requirements-feedback: Was missing Overview section (now fixed)

Fixes #249

## How Has This Been Tested?

**Test Configuration**:
- Claude Code version: Latest
- GitHub CLI version: 2.x
- OS: macOS

**Test Steps**:
1. Ran `markdownlint plugins/requirements-expert/skills/requirements-feedback/SKILL.md` - passed
2. Verified section placement matches other skills (between "Command Integration" and next content section)
3. Verified word count of Overview section (~80 words, within guidelines)

## Checklist

### General

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas (if applicable)
- [x] My changes generate no new warnings or errors

### Documentation

- [x] I have updated the documentation accordingly (README.md, CLAUDE.md, or component docs)
- [x] I have updated YAML frontmatter (if applicable)
- [x] I have verified all links work correctly

### Markdown

- [x] I have run `markdownlint` and fixed all issues
- [x] My markdown follows the repository style (ATX headers, dash lists, fenced code blocks)
- [x] I have verified special HTML elements are properly closed (`<example>`, `<commentary>`, etc.)

### Component-Specific Checks

#### Skills (if applicable)

- [x] Description uses third-person with specific trigger phrases
- [x] SKILL.md is under 2,000 words (progressive disclosure)
- [x] Detailed content is in `references/` subdirectory
- [x] Templates follow the established format

### Testing

- [x] I have tested the plugin locally with `cc --plugin-dir plugins/requirements-expert`
- [x] I have tested the full workflow (if applicable)
- [ ] I have verified GitHub CLI integration works (if applicable) - N/A for docs change
- [ ] I have tested in a clean repository (not my development repo) - N/A for docs change

## Additional Notes

The Overview content is approximately 80 words and matches the style and tone of Overview sections in other skills. It explains:
- What requirements feedback is (systematic process of gathering/analyzing/incorporating input)
- How it differs from static documentation (living documents in GitHub Projects)
- What the skill guides (collection and integration of feedback across the requirements lifecycle)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)