### PR TITLE
docs(skill): add Purpose section to requirements-feedback skill

### DIFF
--- a/plugins/requirements-expert/skills/requirements-feedback/SKILL.md
+++ b/plugins/requirements-expert/skills/requirements-feedback/SKILL.md
@@ -24,6 +24,22 @@ The `/re:review` and `/re:status` commands handle automated validation. This ski
 
 Requirements feedback is the systematic process of gathering, analyzing, and incorporating input from users, stakeholders, and team members throughout the requirements lifecycle. Unlike static documentation, requirements in GitHub Projects are living documents that evolve as understanding deepens. This skill guides the collection and integration of feedback to continuously refine vision, epics, user stories, and tasks—ensuring requirements stay aligned with real-world needs and learnings.
 
+## Purpose
+
+Feedback serves as the quality assurance layer across the requirements hierarchy:
+
+- **Vision level**: Validates problem understanding and strategic alignment
+- **Epic level**: Confirms capability scope and feasibility
+- **Story level**: Refines user value and acceptance criteria
+- **Task level**: Surfaces implementation insights and blockers
+
+Effective feedback:
+
+- Catches misunderstandings early before costly rework
+- Incorporates real-world learnings into requirements
+- Keeps requirements aligned with evolving user needs
+- Enables data-driven refinement of priorities and scope
+
 ## Feedback at Each Stage
 
 Each level of the requirements hierarchy has distinct feedback needs. For detailed guidance on who to involve, what questions to ask, and how to incorporate feedback at each level, see `references/stage-feedback-guide.md`.


### PR DESCRIPTION
## Summary

- Add Purpose section to requirements-feedback skill SKILL.md
- Aligns with the other 5 skills that already have this section
- Explains feedback's role as the quality assurance layer across the requirements hierarchy

Fixes #250

## Problem

The requirements-feedback skill was missing a "Purpose" section that all other 5 skills have:

| Skill | Purpose Section |
|-------|-----------------|
| vision-discovery | ✅ |
| epic-identification | ✅ |
| user-story-creation | ✅ |
| task-breakdown | ✅ |
| prioritization | ✅ |
| requirements-feedback | ❌ (before this PR) |

## Solution

Added the Purpose section after the Overview section, following the standard section ordering pattern used across all skills. The content explains:

1. Feedback's role as quality assurance across the requirements hierarchy (Vision, Epic, Story, Task levels)
2. The benefits of effective feedback (catching misunderstandings, incorporating learnings, keeping alignment)

## Changes

- `plugins/requirements-expert/skills/requirements-feedback/SKILL.md`: Added Purpose section (~16 lines, ~80 words)

## Testing

- [x] Markdownlint passes
- [x] All 6 skills now have Purpose sections (verified with grep)
- [x] Section ordering matches other skills

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)