### PR TITLE
docs(skill): add Feedback Collection Process to requirements-feedback skill

### DIFF
--- a/plugins/requirements-expert/skills/requirements-feedback/SKILL.md
+++ b/plugins/requirements-expert/skills/requirements-feedback/SKILL.md
@@ -40,6 +40,106 @@ Effective feedback:
 - Keeps requirements aligned with evolving user needs
 - Enables data-driven refinement of priorities and scope
 
+## Feedback Collection Process
+
+### Step 1: Collect Feedback
+
+**Key Actions:**
+
+- Gather insights from users, stakeholders, and team members
+- Use appropriate techniques for each audience (see `references/feedback-techniques.md`)
+- Document feedback systematically with source, date, and context
+
+**Guidelines:**
+
+- Match technique to audience: interviews for stakeholders, testing for users
+- Capture both explicit feedback and observed behaviors
+- Reference "Feedback at Each Stage" below for level-specific guidance
+
+### Step 2: Analyze Feedback
+
+**Key Actions:**
+
+- Identify patterns and themes across multiple feedback sources
+- Validate assumptions against collected data
+- Extract actionable insights from raw feedback
+
+**Guidelines:**
+
+- Look for recurring themes—single data points may be outliers
+- Separate signal from noise; not all feedback requires action
+- Note conflicting feedback for stakeholder discussion
+
+### Step 3: Decide
+
+**Key Actions:**
+
+- Prioritize feedback items by impact and alignment with vision
+- Determine which changes to make to requirements
+- Document decisions and rationale
+
+**Guidelines:**
+
+- Use impact/effort analysis for prioritization
+- Involve stakeholders in decisions affecting scope or priority
+- Some feedback may be deferred to future iterations—document explicitly
+
+### Step 4: Update
+
+**Key Actions:**
+
+- Modify GitHub issues (vision, epics, stories, tasks) based on decisions
+- Update acceptance criteria to reflect new understanding
+- Adjust priorities if feedback changes relative importance
+
+**Guidelines:**
+
+- Add comments explaining what changed and why
+- Keep changes traceable via GitHub's edit history
+- Tag relevant team members on significant updates
+
+### Step 5: Communicate
+
+**Key Actions:**
+
+- Inform stakeholders and team of changes made
+- Explain how specific feedback was incorporated
+- Acknowledge feedback providers
+
+**Guidelines:**
+
+- Close the loop—tell people how their input was used
+- Explain decisions even when feedback wasn't incorporated
+- Use GitHub comments to keep communication in context
+
+### Step 6: Validate
+
+**Key Actions:**
+
+- Verify changes actually address the original feedback
+- Check for unintended consequences of updates
+- Confirm with feedback source when appropriate
+
+**Guidelines:**
+
+- Quick review with original feedback provider builds trust
+- Watch for ripple effects on related requirements
+- Iterate if validation reveals issues
+
+### Step 7: Repeat
+
+**Key Actions:**
+
+- Schedule regular feedback cycles throughout the project
+- Build feedback collection into standard workflows
+- Continuously refine based on ongoing learnings
+
+**Guidelines:**
+
+- Don't wait for perfect timing—continuous feedback beats batched reviews
+- Adjust feedback frequency based on project phase
+- Feedback is an ongoing activity, not a one-time event
+
 ## Feedback at Each Stage
 
 Each level of the requirements hierarchy has distinct feedback needs. For detailed guidance on who to involve, what questions to ask, and how to incorporate feedback at each level, see `references/stage-feedback-guide.md`.


### PR DESCRIPTION
## Summary

Adds a numbered 7-step "Feedback Collection Process" section to the requirements-feedback skill, bringing it in line with the structure of all other skills in the plugin.

Fixes #251

## Problem

The requirements-feedback skill was the only skill without a numbered step-by-step process section. All other skills have them:

| Skill | Process Steps |
|-------|---------------|
| vision-discovery | 5 steps |
| epic-identification | 7 steps |
| user-story-creation | 7 steps |
| task-breakdown | 6 steps |
| prioritization | 6 steps |
| requirements-feedback | ❌ None → ✅ 7 steps |

## Solution

Added a "Feedback Collection Process" section that expands the existing Quick Reference 7-step flow with detailed **Key Actions** and **Guidelines** for each step:

1. **Collect Feedback** - gathering insights and documentation
2. **Analyze Feedback** - identifying patterns and insights
3. **Decide** - prioritizing and determining changes
4. **Update** - modifying GitHub issues based on decisions
5. **Communicate** - informing stakeholders of changes
6. **Validate** - verifying changes address feedback
7. **Repeat** - establishing continuous feedback cycles

### Alternatives Considered

The issue suggested adding a new "Identify Feedback Sources" step before "Collect Feedback". However, this would:
- Create inconsistency with the existing Quick Reference section
- Duplicate content already in the "Feedback at Each Stage" section and `references/stage-feedback-guide.md`

Instead, I expanded the existing 7 steps, incorporating source identification guidance into Step 1 (Collect Feedback).

## Changes

- `plugins/requirements-expert/skills/requirements-feedback/SKILL.md`: Added 100 lines containing the new Feedback Collection Process section

## Metrics

- Word count: 1,136 → 1,679 words (now within 1,500-2,000 target)
- Section added: 100 lines

## Testing

- [x] Markdown linting passes
- [x] Content follows existing skill patterns
- [x] Steps align with Quick Reference section

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Changes are focused and minimal

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)