### PR TITLE
docs(skill): expand Best Practices section in requirements-feedback skill

### DIFF
--- a/plugins/requirements-expert/skills/requirements-feedback/SKILL.md
+++ b/plugins/requirements-expert/skills/requirements-feedback/SKILL.md
@@ -191,38 +191,73 @@ Living document principles:
 
 ### Create Safe Space for Feedback
 
+A psychologically safe environment encourages honest input. When people fear blame or dismissal, they withhold valuable insights that could prevent costly mistakes.
+
 - Make it safe to say "this requirement doesn't make sense"
 - Reward people who catch problems early
 - Avoid blame when requirements change
 - Ask open questions: "What is missing?"
 
+**Examples:**
+
+- ✅ "Thanks for catching that gap—let's update the story"
+- ❌ "Why didn't anyone mention this earlier?"
+
 ### Act on Feedback Quickly
+
+Timely action on feedback builds trust and keeps requirements aligned with reality. Delays cause context to fade and signal that input isn't valued.
 
 - Update requirements soon after feedback (while fresh)
 - Communicate changes to those who provided feedback
 - Tell people how their feedback was used
 - Explain decisions (even if feedback not incorporated)
 
+**Examples:**
+
+- ✅ Update the story within 24 hours and comment: "Updated based on your input—added mobile-responsive criterion"
+- ❌ Collect feedback in a meeting, then take no action for weeks
+
 ### Balance Stability and Flexibility
+
+Requirements need enough stability for planning while remaining flexible enough to incorporate learnings. Neither rigid contracts nor constant churn serve the project well.
 
 - Batch small changes; major changes require broader review
 - New information should lead to updates
 - Better to change requirements than build wrong thing
 - Adaptability is a strength, not weakness
 
+**Examples:**
+
+- ✅ "We learned users need bulk upload—adding it to the sprint backlog"
+- ❌ Refuse to update stories because "we already agreed on the scope"
+
 ### Document the "Why" Behind Changes
+
+Clear documentation of change rationale preserves context for future decisions. Without the "why," teams lose valuable institutional knowledge and may repeat past mistakes.
 
 - Add comment explaining significant updates
 - Reference supporting evidence (user quotes, data)
 - Tag relevant people
 - GitHub tracks all changes to issues via edit history
 
+**Examples:**
+
+- ✅ "Changed from 'export to PDF' to 'export to CSV' based on user research showing 80% prefer spreadsheet format"
+- ❌ Silently edit the acceptance criteria with no explanation
+
 ### Validate with Real Users
+
+Internal assumptions can diverge from actual user needs. Regular validation with real users grounds requirements in observable behavior rather than guesswork.
 
 - Get outside perspective regularly
 - Test assumptions with actual users
 - Observe real usage, not just opinions
 - Gather feedback early, before reaching completion
+
+**Examples:**
+
+- ✅ Schedule bi-weekly usability sessions with 3-5 representative users
+- ❌ Wait until launch to discover users expected different functionality
 
 ## Common Pitfalls to Avoid
 


### PR DESCRIPTION
## Summary

Expands the Best Practices section in the requirements-feedback skill with explanatory context and good/bad example patterns for each subsection, improving consistency with other skills.

## Problem

The Best Practices section had 5 subsections with brief bullet points only, lacking the explanatory context and example patterns that other skills have.

Fixes #252

## Solution

Added to each of the five Best Practices subsections:
- **Introductory paragraph**: Brief explanation of the rationale/importance
- **Examples section**: ✅ good and ❌ bad patterns showing correct vs incorrect approaches

### Subsections Enhanced

1. **Create Safe Space for Feedback** - Why psychological safety matters for honest input
2. **Act on Feedback Quickly** - Why timely action builds trust
3. **Balance Stability and Flexibility** - Finding the right balance between rigidity and churn
4. **Document the "Why" Behind Changes** - Preserving context for future decisions
5. **Validate with Real Users** - Grounding requirements in observable behavior

## Changes

- `plugins/requirements-expert/skills/requirements-feedback/SKILL.md`: Added ~300 words of explanatory context and 10 examples (5 good, 5 bad)

## Testing

- [x] Markdown linting passes (`markdownlint plugins/requirements-expert/skills/requirements-feedback/SKILL.md`)
- [x] Word count now 1,921 (within 1,500-2,000 target range)
- [x] Format consistent with other skills (especially user-story-creation)

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Changes are focused and minimal
- [x] Documentation updated

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)