### PR TITLE
docs(skill): add explicit Quick Reference labels to skill content

### DIFF
--- a/plugins/requirements-expert/skills/epic-identification/SKILL.md
+++ b/plugins/requirements-expert/skills/epic-identification/SKILL.md
@@ -143,7 +143,9 @@ Create clear, descriptive titles and summaries:
 - ❌ "Make users happy" (outcome, not capability)
 - ❌ "Phase 1" (not descriptive)
 
-### Epic Issue Template (Minimal)
+### Epic Issue Template (Quick Reference)
+
+_For comprehensive templates with domain-specific examples, see `references/epic-template.md`._
 
 ```markdown
 ## Epic Overview
@@ -159,8 +161,6 @@ Create clear, descriptive titles and summaries:
 ## Success Criteria
 - [ ] [Measurable outcomes]
 ```
-
-See `references/epic-template.md` for comprehensive templates and domain-specific examples.
 
 ### Step 5: Validate Completeness
 

--- a/plugins/requirements-expert/skills/user-story-creation/SKILL.md
+++ b/plugins/requirements-expert/skills/user-story-creation/SKILL.md
@@ -92,9 +92,9 @@ Apply these guidelines:
 - **Title**: "Filter campaigns by date range"
 - **Description**: Detailed explanation of functionality and value
 
-## INVEST Criteria
+## INVEST Criteria (Quick Reference)
 
-Validate every user story against INVEST criteria:
+_Validate every user story against these criteria. For detailed guidance with examples, see `references/invest-criteria.md`._
 
 | Letter | Criterion | Question |
 |--------|-----------|----------|
@@ -104,8 +104,6 @@ Validate every user story against INVEST criteria:
 | **E** | Estimable | Can the team estimate the effort? |
 | **S** | Small | Can it be completed in 1-5 days? |
 | **T** | Testable | Are there specific acceptance criteria? |
-
-For detailed guidance on each criterion with examples, see `references/invest-criteria.md`.
 
 ## Story Creation Process
 


### PR DESCRIPTION
## Description

Add "(Quick Reference)" labels and italicized notes to clarify the relationship between SKILL.md quick-reference content and detailed reference files.

This implements **Option A** from issue #260, which recommends explicit labeling to help users understand:
- SKILL.md contains quick-reference content for fast access during skill use
- Reference files contain comprehensive guidance with detailed examples

## Type of Change

- [x] Documentation update (improvements to README, CLAUDE.md, or component docs)

## Component(s) Affected

- [x] Skills (methodology and best practices)

## Motivation and Context

Two skills contain content that appears in both SKILL.md and their reference files:

1. **epic-identification**: "Epic Issue Template (Minimal)" overlaps with `references/epic-template.md`
2. **user-story-creation**: INVEST criteria table overlaps with `references/invest-criteria.md`

The issue notes that while the skill-development guide discourages duplication, it also acknowledges that quick-reference summaries in SKILL.md can be valuable when clearly labeled as such.

Fixes #260

## How Has This Been Tested?

**Test Configuration**:
- Claude Code version: latest
- GitHub CLI version: 2.x
- OS: macOS

**Test Steps**:
1. Verified markdownlint passes: `markdownlint plugins/requirements-expert/skills/epic-identification/SKILL.md plugins/requirements-expert/skills/user-story-creation/SKILL.md`
2. Reviewed changes to ensure labels are clear and notes are properly formatted
3. Verified reference file paths are correct

## Checklist

### General

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings or errors

### Documentation

- [x] I have verified all links work correctly

### Markdown

- [x] I have run `markdownlint` and fixed all issues
- [x] My markdown follows the repository style (ATX headers, dash lists, fenced code blocks)

### Component-Specific Checks

#### Skills (if applicable)

- [x] SKILL.md is under 2,000 words (progressive disclosure)
- [x] Detailed content is in `references/` subdirectory

## Changes Made

### epic-identification/SKILL.md
- Renamed "Epic Issue Template (Minimal)" → "Epic Issue Template (Quick Reference)"
- Added italicized note at top pointing to comprehensive template
- Removed duplicate reference at bottom (now at top)

### user-story-creation/SKILL.md
- Added "(Quick Reference)" to "INVEST Criteria" heading
- Combined intro text with reference link into italicized note
- Removed duplicate reference at bottom (now at top)

## Additional Notes

This change improves clarity without removing useful quick-access content. The approach balances:
- Having useful quick-reference content in SKILL.md for fast access
- Making the relationship to detailed references explicit
- Following the spirit of avoiding confusing duplication

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)