### PR TITLE
fix(command): add missing tool permissions to review and status commands

### DIFF
--- a/plugins/requirements-expert/commands/review.md
+++ b/plugins/requirements-expert/commands/review.md
@@ -1,7 +1,7 @@
 ---
 name: re:review
 description: Validate requirements for completeness, consistency, quality, and traceability
-allowed-tools: [Bash, Read]
+allowed-tools: [AskUserQuestion, Bash, Read]
 ---
 
 # Review & Validate Requirements

--- a/plugins/requirements-expert/commands/status.md
+++ b/plugins/requirements-expert/commands/status.md
@@ -1,7 +1,7 @@
 ---
 name: re:status
 description: Show comprehensive overview of requirements project status, progress, and health
-allowed-tools: [Bash, Read]
+allowed-tools: [AskUserQuestion, Bash, Read, Write]
 ---
 
 # Requirements Project Status


### PR DESCRIPTION
## Description

Add missing tool declarations to `allowed-tools` frontmatter in `review.md` and `status.md` commands to prevent runtime failures when interactive features are invoked.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Component(s) Affected

- [x] Commands (`/re:*`)

## Motivation and Context

Commands were referencing tools in their instructions that weren't declared in the `allowed-tools` frontmatter field:

- `review.md` Step 6 uses `AskUserQuestion` to offer interactive issue fixing
- `status.md` Step 5 uses `AskUserQuestion` for export options and `Write` for file export

This caused runtime failures when these features were triggered.

Fixes #266

## How Has This Been Tested?

**Test Configuration**:
- GitHub CLI version: 2.x
- OS: macOS

**Test Steps**:
1. Verified YAML frontmatter syntax is correct
2. Ran `markdownlint` on modified files - no issues
3. Compared with other commands that successfully use `AskUserQuestion`

## Checklist

### General

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings or errors

### Markdown

- [x] I have run `markdownlint` and fixed all issues
- [x] My markdown follows the repository style (ATX headers, dash lists, fenced code blocks)

### Component-Specific Checks

#### Commands

- [x] GitHub CLI commands are properly formatted
- [x] Success/failure messages are clear and helpful

## Changes Made

- `review.md`: Added `AskUserQuestion` to allowed-tools (`[Bash, Read]` → `[AskUserQuestion, Bash, Read]`)
- `status.md`: Added `AskUserQuestion` and `Write` to allowed-tools (`[Bash, Read]` → `[AskUserQuestion, Bash, Read, Write]`)

## Reviewer Notes

**Areas that need special attention**:
- This is a minimal, targeted fix for a critical blocking issue
- The fix follows the exact pattern used by other commands (create-stories, create-tasks, etc.)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)