### PR TITLE
docs(command): clarify SlashCommand tool for command chaining

### DIFF
--- a/plugins/requirements-expert/commands/create-stories.md
+++ b/plugins/requirements-expert/commands/create-stories.md
@@ -191,8 +191,8 @@ Use AskUserQuestion:
 
 **Handle response:**
 - "Create stories for another epic": Restart from Step 1
-- "Prioritize stories": Execute `/re:prioritize`
-- "Create tasks for a story": Execute `/re:create-tasks`
+- "Prioritize stories": Use the SlashCommand tool to invoke `/re:prioritize`
+- "Create tasks for a story": Use the SlashCommand tool to invoke `/re:create-tasks`
 - "Done for now": Show success message
 
 ### Step 9: Success Message

--- a/plugins/requirements-expert/commands/create-tasks.md
+++ b/plugins/requirements-expert/commands/create-tasks.md
@@ -250,7 +250,7 @@ Use AskUserQuestion:
 
 **Handle response:**
 - "Create tasks for another story": Restart from Step 1
-- "Check project status": Execute `/re:status`
+- "Check project status": Use the SlashCommand tool to invoke `/re:status`
 - "Done for now": Exit
 
 ## Error Handling

--- a/plugins/requirements-expert/commands/discover-vision.md
+++ b/plugins/requirements-expert/commands/discover-vision.md
@@ -201,7 +201,7 @@ Use AskUserQuestion:
 - multiSelect: false
 
 If user selects "Yes":
-- Execute `/re:identify-epics` command
+- Use the SlashCommand tool to invoke `/re:identify-epics`
 
 ## Error Handling
 

--- a/plugins/requirements-expert/commands/identify-epics.md
+++ b/plugins/requirements-expert/commands/identify-epics.md
@@ -165,7 +165,7 @@ Use AskUserQuestion:
   - "No, I'll prioritize later" (description: "Skip prioritization for now")
 - multiSelect: false
 
-If "Yes": Execute `/re:prioritize` command
+If "Yes": Use the SlashCommand tool to invoke `/re:prioritize`
 
 If "No": Show next steps
 


### PR DESCRIPTION
## Description

Commands that chain to other `/re:*` commands now explicitly instruct Claude to use the SlashCommand tool instead of ambiguous "Execute" language. This ensures Claude knows the correct mechanism to invoke other commands.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update (improvements to README, CLAUDE.md, or component docs)
- [ ] Refactoring (code change that neither fixes a bug nor adds a feature)
- [ ] Configuration change (changes to .markdownlint.json, plugin.json, etc.)

## Component(s) Affected

- [x] Commands (`/re:*`)
- [ ] Skills (methodology and best practices)
- [ ] Agents (requirements-assistant, requirements-validator)
- [ ] Hooks (UserPromptSubmit)
- [ ] Documentation (README.md, CLAUDE.md, SECURITY.md)
- [ ] Configuration (.markdownlint.json, plugin.json, marketplace.json)
- [ ] Issue/PR templates
- [ ] Other (please specify):

## Motivation and Context

Four commands mention executing other `/re:*` commands but don't specify HOW Claude should do this. Commands cannot directly execute other commands - Claude must use the SlashCommand tool. Without explicit mention, Claude might try to execute commands as text or fail to chain properly.

Fixes #270

## How Has This Been Tested?

**Test Configuration**:
- Changes are documentation-only instructional updates
- Linting verified: `markdownlint` passes on all modified files

**Test Steps**:
1. Verified each command file's chaining instruction was updated
2. Ran `markdownlint` on all 4 modified files - passed

## Checklist

### General

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas (if applicable)
- [x] My changes generate no new warnings or errors

### Documentation

- [x] I have updated the documentation accordingly (README.md, CLAUDE.md, or component docs)
- [x] I have updated YAML frontmatter (if applicable)
- [x] I have verified all links work correctly

### Markdown

- [x] I have run `markdownlint` and fixed all issues
- [x] My markdown follows the repository style (ATX headers, dash lists, fenced code blocks)
- [x] I have verified special HTML elements are properly closed (`<example>`, `<commentary>`, etc.)

### Component-Specific Checks

#### Commands (if applicable)

- [x] Command uses imperative form ("Do X", not "You should do X")
- [x] Error handling is included for common failure modes
- [x] GitHub CLI commands are properly formatted
- [x] Success/failure messages are clear and helpful

## Additional Notes

The change follows the pattern from Claude Code documentation which states: "Use the SlashCommand tool to execute them."

Updated command chaining locations:
- `discover-vision.md` line 204: chains to `/re:identify-epics`
- `identify-epics.md` line 168: chains to `/re:prioritize`
- `create-stories.md` lines 194-195: chains to `/re:prioritize` and `/re:create-tasks`
- `create-tasks.md` line 253: chains to `/re:status`

## Reviewer Notes

**Areas that need special attention**:
- Consistency of the new wording across all four files

**Known limitations or trade-offs**:
- None - this is a straightforward clarification

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)