### PR TITLE
docs(command): remove user-facing language from commands

### DIFF
--- a/plugins/requirements-expert/commands/create-stories.md
+++ b/plugins/requirements-expert/commands/create-stories.md
@@ -211,8 +211,6 @@ Next Steps:
 2. Run `/re:create-tasks` to break down highest-priority story
 3. Review stories and refine acceptance criteria
 4. Use `/re:status` to see progress
-
-Pro tip: Tackle stories one at a time - implement, test, ship, repeat!
 ```
 
 ## Error Handling

--- a/plugins/requirements-expert/commands/create-tasks.md
+++ b/plugins/requirements-expert/commands/create-tasks.md
@@ -205,8 +205,6 @@ Display task execution order:
 **Phase 3 (Integration & Testing):**
 - #[num] - Integration tests
 - #[num] - Documentation
-
-Tip: Mark tasks as "In Progress" in GitHub Projects as you work on them!
 ```
 
 ### Step 8: Success Message & Assignment
@@ -233,8 +231,6 @@ Next Steps:
 3. Start with Phase 1 tasks (no dependencies)
 4. Update task status as you progress
 5. When all tasks complete, story is complete!
-
-Pro tip: Use `gh issue list --label type:task --assignee @me` to see your assigned tasks!
 ```
 
 ### Step 9: Continue or Stop

--- a/plugins/requirements-expert/commands/discover-vision.md
+++ b/plugins/requirements-expert/commands/discover-vision.md
@@ -186,8 +186,6 @@ Next Steps:
 2. Share with stakeholders for feedback
 3. Run `/re:identify-epics` to identify major capabilities
 4. Use `/re:review` to validate the vision
-
-Pro tip: The vision is a living document - update it as you learn more!
 ```
 
 ### Step 7: Offer to Continue

--- a/plugins/requirements-expert/commands/identify-epics.md
+++ b/plugins/requirements-expert/commands/identify-epics.md
@@ -182,8 +182,6 @@ Next Steps:
 2. Review epic issues and add details as needed
 3. Run `/re:create-stories` to break down highest-priority epic
 4. Use `/re:status` to see project overview
-
-Pro tip: Start with one epic, create stories for it, then move to the next!
 ```
 
 ## Error Handling

--- a/plugins/requirements-expert/commands/prioritize.md
+++ b/plugins/requirements-expert/commands/prioritize.md
@@ -165,8 +165,6 @@ Display:
 - Begin implementation with Must Have tasks
 - Follow dependency order within priority level
 - Update task status in GitHub Projects as you progress
-
-Pro tip: Re-prioritize regularly as you learn more!
 ```
 
 ### Step 9: Offer Next Action


### PR DESCRIPTION
## Description

Remove inappropriate user-facing language ("Pro tip:" and "Tip:") from command files. Commands are instructions FOR Claude, not messages TO users.

## Type of Change

- [x] Documentation update (improvements to README, CLAUDE.md, or component docs)

## Component(s) Affected

- [x] Commands (`/re:*`)

## Motivation and Context

Commands contain user-facing language like "Pro tip:" which violates best practices. From Claude Code command development guidelines: "Commands are written for agent consumption, not human consumption. Write commands as directives TO Claude about what to do, not as messages TO the user."

Fixes #271

## How Has This Been Tested?

**Test Configuration**:
- Claude Code version: claude-opus-4-5-20251101
- GitHub CLI version: 2.x
- OS: macOS Darwin 25.1.0

**Test Steps**:
1. Searched for all "Pro tip:" and "Tip:" occurrences
2. Removed 6 instances across 5 command files
3. Verified no instances remain with `grep -r "Pro tip:" commands/`
4. Ran `markdownlint` on all modified files - passed

## Checklist

### General

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings or errors

### Documentation

- [x] I have updated the documentation accordingly
- [x] I have verified all links work correctly

### Markdown

- [x] I have run `markdownlint` and fixed all issues
- [x] My markdown follows the repository style (ATX headers, dash lists, fenced code blocks)

### Component-Specific Checks

#### Commands

- [x] Command uses imperative form ("Do X", not "You should do X")
- [x] GitHub CLI commands are properly formatted
- [x] Success/failure messages are clear and helpful

## Files Changed

| File | Change |
|------|--------|
| `commands/discover-vision.md` | Removed "Pro tip: The vision is a living document..." |
| `commands/identify-epics.md` | Removed "Pro tip: Start with one epic..." |
| `commands/create-stories.md` | Removed "Pro tip: Tackle stories one at a time..." |
| `commands/create-tasks.md` | Removed "Tip: Mark tasks as In Progress..." and "Pro tip: Use gh issue list..." |
| `commands/prioritize.md` | Removed "Pro tip: Re-prioritize regularly..." |

## Approach Taken

Simply removed the lines rather than converting to directives because:
1. The issue suggests removal if not critical to Claude's instructions
2. These tips are contextual guidance Claude can provide naturally
3. The "Next Steps" sections already provide actionable guidance
4. Keeping commands focused on instructions, not scripted messages

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)