### PR TITLE
fix: shorten AskUserQuestion headers to ≤12 characters

### DIFF
--- a/plugins/requirements-expert/commands/create-stories.md
+++ b/plugins/requirements-expert/commands/create-stories.md
@@ -68,7 +68,7 @@ These cover the main user journeys - would you like to add, remove, or modify an
 
 Use AskUserQuestion:
 - Question: "Which stories should we include?"
-- Header: "Story Selection"
+- Header: "Stories"
 - Options: One per suggested story (label = short title, description = full story)
 - multiSelect: true
 

--- a/plugins/requirements-expert/commands/create-tasks.md
+++ b/plugins/requirements-expert/commands/create-tasks.md
@@ -92,7 +92,7 @@ Estimated: [X] tasks total
 
 Use AskUserQuestion:
 - Question: "Which tasks should we create?"
-- Header: "Task Selection"
+- Header: "Tasks"
 - Options: One per suggested task
 - multiSelect: true
 

--- a/plugins/requirements-expert/commands/discover-vision.md
+++ b/plugins/requirements-expert/commands/discover-vision.md
@@ -65,7 +65,7 @@ Note: Users can select "Other" to describe different user types.
 
 Use AskUserQuestion:
 - question: "How do users currently address this problem?"
-- header: "Current State"
+- header: "Current"
 - multiSelect: false
 - options:
   - label: "Manual workarounds", description: "Spreadsheets, documents, manual processes"
@@ -79,7 +79,7 @@ Note: Users can select "Other" to describe different current approaches.
 
 Use AskUserQuestion:
 - question: "What category best describes your solution?"
-- header: "Solution Type"
+- header: "Solution"
 - multiSelect: false
 - options:
   - label: "Automation tool", description: "Automates manual or repetitive tasks"
@@ -95,7 +95,7 @@ After the user selects a category, ask a follow-up to get the one-sentence solut
 
 Use AskUserQuestion:
 - question: "What is your primary differentiator?"
-- header: "Differentiator"
+- header: "Advantage"
 - multiSelect: false
 - options:
   - label: "Speed/Performance", description: "Faster or more efficient than alternatives"

--- a/plugins/requirements-expert/commands/identify-epics.md
+++ b/plugins/requirements-expert/commands/identify-epics.md
@@ -62,7 +62,7 @@ Use AskUserQuestion to refine the epic list:
 
 **Question 1:**
 - Question: "Which of these suggested epics should we include? (Select all that apply)"
-- Header: "Epic Selection"
+- Header: "Epics"
 - multiSelect: true
 - Options: One option per suggested epic (label = epic name, description = brief desc)
 

--- a/plugins/requirements-expert/commands/prioritize.md
+++ b/plugins/requirements-expert/commands/prioritize.md
@@ -16,7 +16,7 @@ Load the **prioritization** skill to access MoSCoW framework methodology.
 
 Use AskUserQuestion:
 - Question: "What would you like to prioritize?"
-- Header: "Prioritization Level"
+- Header: "Level"
 - Options:
   - "Epics" (description: "Prioritize all epics - determine which capabilities to build first")
   - "Stories for an epic" (description: "Prioritize user stories within a specific epic")


### PR DESCRIPTION
## Summary

Fixes 7 AskUserQuestion headers across 5 commands that exceeded Claude Code's 12-character limit for chip/tag display.

## Problem

AskUserQuestion headers are displayed as short labels/chips in the UI. The Claude Code specification requires these to be ≤12 characters, but 7 headers violated this constraint.

Fixes #283

## Solution

Shortened all non-compliant headers while maintaining clarity:

| Command | Before | After | Length |
|---------|--------|-------|--------|
| `re:discover-vision` | "Current State" | "Current" | 13→7 |
| `re:discover-vision` | "Solution Type" | "Solution" | 13→8 |
| `re:discover-vision` | "Differentiator" | "Advantage" | 14→9 |
| `re:identify-epics` | "Epic Selection" | "Epics" | 14→5 |
| `re:create-stories` | "Story Selection" | "Stories" | 15→7 |
| `re:create-tasks` | "Task Selection" | "Tasks" | 14→5 |
| `re:prioritize` | "Prioritization Level" | "Level" | 20→5 |

## Changes

- `plugins/requirements-expert/commands/discover-vision.md`: 3 header fixes
- `plugins/requirements-expert/commands/identify-epics.md`: 1 header fix
- `plugins/requirements-expert/commands/create-stories.md`: 1 header fix
- `plugins/requirements-expert/commands/create-tasks.md`: 1 header fix
- `plugins/requirements-expert/commands/prioritize.md`: 1 header fix

## Testing

- [x] All modified files pass markdownlint
- [x] Headers maintain semantic clarity while being ≤12 characters

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Changes are focused and minimal

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)