### PR TITLE
docs: document ${CLAUDE_PLUGIN_ROOT} limitation for command files

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -194,6 +194,35 @@ Only four priority levels (no custom priorities):
 - **Could Have**: ~20% of items
 - **Won't Have**: Explicitly documented exclusions
 
+### 6. Template File Path Pattern
+
+Commands reference template files using repository-relative paths:
+
+```markdown
+plugins/requirements-expert/skills/vision-discovery/references/vision-template.md
+```
+
+**Why not `${CLAUDE_PLUGIN_ROOT}`?**
+
+The `${CLAUDE_PLUGIN_ROOT}` variable only works in JSON configuration files (hooks.json, MCP servers). It does **not** expand in command markdown files due to a known limitation ([anthropics/claude-code#9354](https://github.com/anthropics/claude-code/issues/9354)).
+
+**Current approach:**
+
+- Commands use repository-relative paths starting with `plugins/requirements-expert/`
+- Paths are resolved by the Read tool from the working directory
+- Works correctly for local development and testing
+
+**Affected commands:**
+
+| Command | Template Path |
+|---------|---------------|
+| `re:discover-vision` | `skills/vision-discovery/references/vision-template.md` |
+| `re:identify-epics` | `skills/epic-identification/references/epic-template.md` |
+| `re:create-stories` | `skills/user-story-creation/references/story-template.md` |
+| `re:create-tasks` | `skills/task-breakdown/references/task-template.md` |
+
+**If the limitation is fixed:** Commands could migrate to `${CLAUDE_PLUGIN_ROOT}/skills/.../references/*.md` for true portability across installation contexts.
+
 ## Working with Components
 
 ### Adding a New Command
@@ -681,7 +710,7 @@ When modifying this plugin:
 1. **Don't create local requirement files** - Everything goes in GitHub issues in GitHub Projects
 2. **Don't skip state validation** - Always check what exists before suggesting next action
 3. **Don't use second person in skills** - Use imperative form ("Do X" not "You should do X")
-4. **Don't hardcode paths** - Use `${CLAUDE_PLUGIN_ROOT}` if needed (though not used in this plugin)
+4. **Don't expect `${CLAUDE_PLUGIN_ROOT}` in commands** - It only works in JSON configs (hooks, MCP), not markdown files (see Pattern 6)
 5. **Don't duplicate content** - Between SKILL.md and references/, between README and CLAUDE.md
 6. **Don't make up GitHub issue numbers** - Always query actual state
 7. **Don't suggest commands without prerequisites** - Check vision exists before suggesting epics


### PR DESCRIPTION
## Description

Documents the investigation findings for issue #286, explaining why `${CLAUDE_PLUGIN_ROOT}` is not used for template file paths in command markdown files.

Key findings:
- `${CLAUDE_PLUGIN_ROOT}` only works in JSON config files (hooks.json, MCP servers)
- It does NOT expand in command markdown files (documented bug: anthropics/claude-code#9354)
- Current repository-relative paths work correctly for local development
- Commands could migrate if the limitation is resolved upstream

## Type of Change

- [x] Documentation update (improvements to README, CLAUDE.md, or component docs)

## Component(s) Affected

- [x] Documentation (README.md, CLAUDE.md, SECURITY.md)

## Motivation and Context

Issue #286 asked to evaluate using `${CLAUDE_PLUGIN_ROOT}` for template file paths. Investigation revealed this is not viable due to a known Claude Code limitation where the variable doesn't expand in markdown files.

Rather than implement a broken solution, this PR documents:
1. Why the current approach is used (Pattern 6)
2. The upstream limitation and reference
3. Future migration path if the bug is fixed

Fixes #286

## How Has This Been Tested?

**Test Configuration**:
- Claude Code version: Latest
- GitHub CLI version: 2.x
- OS: macOS

**Test Steps**:
1. Ran `markdownlint CLAUDE.md` - passed with no errors
2. Verified Pattern 6 section renders correctly
3. Verified pitfall #4 reference to Pattern 6 is accurate

## Checklist

### General

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings or errors

### Documentation

- [x] I have updated the documentation accordingly (README.md, CLAUDE.md, or component docs)
- [x] I have verified all links work correctly

### Markdown

- [x] I have run `markdownlint` and fixed all issues
- [x] My markdown follows the repository style (ATX headers, dash lists, fenced code blocks)

## Additional Notes

### Alternatives Considered

1. **Use `${CLAUDE_PLUGIN_ROOT}` in commands** - Not viable due to anthropics/claude-code#9354
2. **Embed templates directly in commands** - Would duplicate content and violate progressive disclosure
3. **Keep current approach and document** - Selected approach ✅

### Investigation Summary

| Scenario | `${CLAUDE_PLUGIN_ROOT}` Works? |
|----------|-------------------------------|
| hooks.json | ✅ Yes |
| MCP server configs | ✅ Yes |
| Command markdown files | ❌ No (bug) |
| Skill markdown files | ❌ No |

### References

- [anthropics/claude-code#9354](https://github.com/anthropics/claude-code/issues/9354) - Variable doesn't expand in markdown

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)