### PR TITLE
feat(commands): add idempotency and recovery handling to re:prioritize

### DIFF
--- a/plugins/requirements-expert/commands/prioritize.md
+++ b/plugins/requirements-expert/commands/prioritize.md
@@ -267,4 +267,6 @@ Use AskUserQuestion:
 - Document rationale for priorities (especially Must Have and Won't Have)
 - Update priorities in both custom fields AND labels for visibility
 - Two-layer metadata (fields + labels) provides both project views and cross-project queries
+- Custom field failures trigger full recovery flow (controls project views)
+- Label failures are non-blocking partial success (avoids excessive prompting, easily fixed manually)
 - Partial failures are tracked separately from complete failures


### PR DESCRIPTION
## Description

Add graceful failure handling to the `/re:prioritize` command when priority updates fail. The command is inherently idempotent (setting the same priority twice is harmless) but now includes proper recovery when operations fail.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to README, CLAUDE.md, or component docs)
- [ ] Refactoring (code change that neither fixes a bug nor adds a feature)
- [ ] Configuration change (changes to .markdownlint.json, plugin.json, etc.)

## Component(s) Affected

- [x] Commands (`/re:*`)
- [ ] Skills (methodology and best practices)
- [ ] Agents (requirements-assistant, requirements-validator)
- [ ] Hooks (UserPromptSubmit)
- [ ] Documentation (README.md, CLAUDE.md, SECURITY.md)
- [ ] Configuration (.markdownlint.json, plugin.json, marketplace.json)
- [ ] Issue/PR templates
- [ ] Other (please specify):

## Motivation and Context

Part of #291 - Add idempotency and interactive recovery handling to commands.

When prioritization fails mid-batch:
1. Some items have priority set, others don't
2. Custom fields and labels may be out of sync
3. User has no clear recovery path
4. Must manually identify which items were updated

This PR adds the same recovery pattern used in `re:create-stories`, `re:create-tasks`, and `re:discover-vision`.

Fixes #296

## Changes Made

### Added to Step 6 (Update GitHub Issues)
- Batch tracking lists: `updated`, `partial`, `failed`, `skipped`
- Interactive recovery for custom field update failures (Retry/Skip/Check permissions/Stop)
- Handling for partial failures (field succeeds but label fails, or vice versa)
- Sub-step structure (6a, 6b, 6c) matching other commands

### Updated Step 8 (Success Message)
- Batch summary format showing updated/partial/failed/skipped counts
- Priority distribution summary
- Execution order for Must Haves
- Recovery guidance for failed items

### Updated Error Handling Section
- Added recovery scenarios for custom field, label, and comment failures
- Added partial completion handling

### Updated Notes Section
- Added idempotency note
- Added notes about two-layer metadata and partial failures

## How Has This Been Tested?

**Test Configuration**:
- Claude Code version: Latest
- GitHub CLI version: 2.x
- OS: macOS

**Test Steps**:
1. Load plugin with `cc --plugin-dir plugins/requirements-expert`
2. Run `markdownlint plugins/requirements-expert/commands/prioritize.md` - passes
3. Verified structural consistency with other commands in the series

## Checklist

### General

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas (if applicable)
- [x] My changes generate no new warnings or errors

### Markdown

- [x] I have run `markdownlint` and fixed all issues
- [x] My markdown follows the repository style (ATX headers, dash lists, fenced code blocks)
- [x] I have verified special HTML elements are properly closed (`<example>`, `<commentary>`, etc.)

### Component-Specific Checks

#### Commands

- [x] Command uses imperative form ("Do X", not "You should do X")
- [x] Error handling is included for common failure modes
- [x] GitHub CLI commands are properly formatted
- [x] Success/failure messages are clear and helpful

## Alternatives Considered

1. **Full recovery for label failures**: Could add the same Retry/Skip/Stop flow for label failures. Decided against this to avoid excessive prompting - partial success is acceptable for labels since they can be fixed manually.

2. **Automatic retry**: Could automatically retry failed operations before prompting. Decided against this as the established pattern in other commands prompts immediately on first failure.

## Additional Notes

This follows the established pattern from:
- `re:create-stories` (#325)
- `re:create-tasks` (#326)
- `re:discover-vision` (#327)

The key difference for `/re:prioritize` is handling partial failures due to the two-layer metadata system (custom fields + labels).

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)