### PR TITLE
fix(ci): correct claude_args escaping for PR review workflow

### DIFF
--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -90,4 +90,4 @@ jobs:
             Be constructive and helpful. Focus on significant issues, not nitpicks.
             If the PR looks good, say so briefly - don't invent problems.
           claude_args: |
-            --allowed-tools Bash(gh pr:*),Bash(npx markdownlint:*),Read,Glob,Grep
+            --allowedTools "Bash(gh pr:*),Bash(npx markdownlint:*),Read,Glob,Grep,mcp__github_inline_comment__create_inline_comment"


### PR DESCRIPTION
## Summary

Fixes shell escaping issue that prevented Claude from running markdownlint during PR reviews.

## Problem

The `--allowed-tools` parameter was being corrupted by shell interpretation:

**Expected:**
```
--allowed-tools Bash(gh pr:*),Bash(npx markdownlint:*),Read,Glob,Grep
```

**Actual (after shell parsing):**
```
--allowed-tools Bash gh ,Bash npx ,Read,Glob,Grep
```

The parentheses, colons, and asterisks were stripped, causing Claude to report "tool not available in CI environment" for markdownlint.

## Root Cause Analysis

Discovered by analyzing workflow run logs from PR #329:
- Run 19922911708: Claude said "markdownlint-cli not available in this environment"
- Run 19923026736: Same escaping issue in logs

The official [claude-code-action example](https://github.com/anthropics/claude-code-action/blob/main/examples/pr-review-comprehensive.yml) shows the correct format with:
1. `--allowedTools` (camelCase, not kebab-case)
2. Tool list wrapped in double quotes

## Changes

- Use `--allowedTools` instead of `--allowed-tools`
- Wrap tool list in double quotes to protect special characters from shell interpretation
- Add `mcp__github_inline_comment__create_inline_comment` for inline code review comments

## Testing

- [x] Workflow validates with `actionlint`
- [ ] PR review workflow successfully runs markdownlint (will verify on this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)