### PR TITLE
fix(ci): correct allowedTools flag format across all workflows

### DIFF
--- a/.github/workflows/ci-failure-analysis.yml
+++ b/.github/workflows/ci-failure-analysis.yml
@@ -160,4 +160,4 @@ jobs:
             After posting (or if no PR found), summarize what you found and what action was taken.
 
           claude_args: |
-            --allowed-tools Bash(gh run:*),Bash(gh pr:*),Read
+            --allowedTools "Bash(gh run:*),Bash(gh pr:*),Read"

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -67,4 +67,4 @@ jobs:
           # Optional: Add claude_args to customize behavior and configuration
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://docs.claude.com/en/docs/claude-code/cli-reference for available options
-          # claude_args: '--allowed-tools Bash(gh pr:*)'
+          # claude_args: '--allowedTools "Bash(gh pr:*)"'

--- a/.github/workflows/component-validation.yml
+++ b/.github/workflows/component-validation.yml
@@ -107,7 +107,7 @@ jobs:
             Set `all_valid` to true only if all categories are valid.
             Include specific file names and line numbers in issues when possible.
           claude_args: |
-            --allowed-tools Read,Glob,Grep
+            --allowedTools "Read,Glob,Grep"
             --json-schema '{"type":"object","properties":{"commands_valid":{"type":"boolean"},"commands_issues":{"type":"array","items":{"type":"string"}},"skills_valid":{"type":"boolean"},"skills_issues":{"type":"array","items":{"type":"string"}},"agents_valid":{"type":"boolean"},"agents_issues":{"type":"array","items":{"type":"string"}},"hooks_valid":{"type":"boolean"},"hooks_issues":{"type":"array","items":{"type":"string"}},"all_valid":{"type":"boolean"},"summary":{"type":"string"}},"required":["all_valid"]}'
 
       - name: Check validation result

--- a/.github/workflows/semantic-labeler.yml
+++ b/.github/workflows/semantic-labeler.yml
@@ -107,7 +107,7 @@ jobs:
 
             After applying labels, briefly explain your reasoning.
           claude_args: |
-            --allowed-tools Bash(gh issue:*)
+            --allowedTools "Bash(gh issue:*)"
 
   label-pr:
     name: Label Pull Request
@@ -196,4 +196,4 @@ jobs:
             After applying labels, briefly explain your reasoning.
           # PR job needs Read,Glob to analyze file changes for accurate component detection
           claude_args: |
-            --allowed-tools Bash(gh pr:*),Read,Glob
+            --allowedTools "Bash(gh pr:*),Read,Glob"

--- a/.github/workflows/version-check.yml
+++ b/.github/workflows/version-check.yml
@@ -62,7 +62,7 @@ jobs:
             - plugins/requirements-expert/skills/prioritization/SKILL.md
             - plugins/requirements-expert/skills/requirements-feedback/SKILL.md
           claude_args: |
-            --allowed-tools Read,Glob
+            --allowedTools "Read,Glob"
             --json-schema '{"type":"object","properties":{"plugin_json_version":{"type":"string","description":"Version from plugin.json"},"marketplace_metadata_version":{"type":"string","description":"Version from marketplace.json metadata.version"},"marketplace_plugin_version":{"type":"string","description":"Version from marketplace.json plugins[0].version"},"skill_versions":{"type":"object","description":"Map of skill name to version","additionalProperties":{"type":"string"}},"all_match":{"type":"boolean","description":"True if all versions match plugin.json"},"expected_version":{"type":"string","description":"The expected version (from plugin.json)"},"mismatches":{"type":"array","description":"List of files with mismatched versions","items":{"type":"string"}}},"required":["plugin_json_version","all_match","expected_version","mismatches"]}'
 
       - name: Report version status

--- a/.github/workflows/weekly-maintenance.yml
+++ b/.github/workflows/weekly-maintenance.yml
@@ -134,4 +134,4 @@ jobs:
             - If a check has no issues, still mention it passed
             - Use the exact run URL provided above in the footer
           claude_args: |
-            --allowed-tools Read,Glob,Grep,Bash(gh issue:*),Bash(gh pr list:*),Bash(git log:*),Bash(date:*)
+            --allowedTools "Read,Glob,Grep,Bash(gh issue:*),Bash(gh pr list:*),Bash(git log:*),Bash(date:*)"


### PR DESCRIPTION
## Summary

Fixes shell escaping issue in all Claude workflow files that use `claude_args`.

## Problem

Two issues with the current `claude_args` configuration:

### 1. Wrong Flag Name
- **Used**: `--allowed-tools` (kebab-case)
- **Correct**: `--allowedTools` (camelCase)

Per [official documentation](https://github.com/anthropics/claude-code-action/blob/main/docs/configuration.md) and [CLI reference](https://code.claude.com/docs/en/cli-reference).

### 2. Missing Quotes Around Tool List
Without quotes, shell interprets parentheses as subshell syntax:

```
# What we pass:
--allowedTools Bash(gh pr:*),Read,Glob

# What shell parses it as:
--allowedTools Bash gh ,Read,Glob
```

The parentheses, colons, and asterisks are stripped, causing Claude to not recognize the tool permissions.

## Discovery

Found while investigating why Claude reported "markdownlint not available in CI environment" despite PR #328 adding `Bash(npx markdownlint:*)` to `claude-pr-review.yml`. Analysis of workflow run logs (runs 19922911708 and 19923026736) showed the corrupted command line.

## Files Changed

| File | Instances Fixed |
|------|-----------------|
| `weekly-maintenance.yml` | 1 |
| `version-check.yml` | 1 |
| `semantic-labeler.yml` | 2 (issue + PR jobs) |
| `component-validation.yml` | 1 |
| `ci-failure-analysis.yml` | 1 |
| `claude.yml` | 1 (commented example) |

## Format Clarification

There are **two different contexts** with different formats:

| Context | Correct Format | Example |
|---------|---------------|---------|
| Plugin YAML frontmatter | `allowed-tools:` | `allowed-tools: [Bash(gh:*), Read]` |
| CLI flags in workflows | `--allowedTools "..."` | `--allowedTools "Bash(gh:*),Read"` |

Plugin command files (`commands/*.md`) correctly use the YAML format. Only workflow files needed fixing.

## Testing

- [x] All 6 workflows pass `actionlint` validation
- [ ] Workflows correctly pass tool permissions to Claude (will verify on next trigger)

## Related

- Follows fix in PR #330 for `claude-pr-review.yml`
- Root cause analysis from PR #329 review comments

🤖 Generated with [Claude Code](https://claude.com/claude-code)