### PR TITLE
feat(ci): enable commit signing for Claude Code Action

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -60,6 +60,7 @@ jobs:
         uses: anthropics/claude-code-action@6337623ebba10cf8c8214b507993f8062fd4ccfb # v1.0.22
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          use_commit_signing: true
 
           # Optional: Give a custom prompt to Claude. If this is not specified, Claude will perform the instructions specified in the comment that tagged it.
           # prompt: 'Update the pull request description to include a summary of changes.'


### PR DESCRIPTION
## Summary

- Enable `use_commit_signing: true` in the Claude Code workflow to ensure commits made by Claude are cryptographically signed

## Why This Change

Commits made by Claude Code Action are unsigned by default. Enabling commit signing provides:

- **Verified badge** on commits made by Claude in the GitHub UI
- **Cryptographic proof** of commit authenticity
- **Compliance** with repository security policies requiring signed commits

## How It Works

When `use_commit_signing: true` is set, the action uses GitHub's API for commits instead of `git commit` + `git push`. This means commits are signed by GitHub's infrastructure and show as "Verified".

See: [claude-code-action security docs](https://github.com/anthropics/claude-code-action/blob/main/docs/security.md#commit-signing)

## Scope

Only `claude.yml` needs this change—it's the only Claude workflow with `contents: write` permission. The other 6 Claude workflows (`weekly-maintenance`, `version-check`, `semantic-labeler`, `component-validation`, `ci-failure-analysis`, `claude-pr-review`) only have `contents: read` and cannot create commits.

## Test plan

- [ ] Trigger Claude via `@claude` mention on a PR
- [ ] Have Claude make a code change that results in a commit
- [ ] Verify the commit shows "Verified" badge in GitHub UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)