### PR TITLE
refactor: leverage user-story-creation skill in create-stories command

### DIFF
--- a/plugins/requirements-expert/commands/create-stories.md
+++ b/plugins/requirements-expert/commands/create-stories.md
@@ -10,7 +10,7 @@ Break down a selected epic into user stories following INVEST criteria and creat
 
 ## Instructions
 
-Load the **user-story-creation** skill for methodology, INVEST criteria, and templates. Load **shared-patterns** skill for error handling and idempotency patterns.
+Load the **user-story-creation** skill for methodology and templates. Load **shared-patterns** skill for error handling and idempotency patterns.
 
 ### Step 1: Select Epic to Break Down
 


### PR DESCRIPTION
## Summary

- Refactor `create-stories.md` from 331 to 159 lines (52% reduction)
- Delegate methodology content to user-story-creation and shared-patterns skills
- Follow same pattern established in identify-epics.md refactor (PR #349)

## Problem

Fixes #339

The `create-stories.md` command had embedded content duplicating skill material:
- Full INVEST criteria explanation
- Story format template
- Given-When-Then format examples
- Verbose idempotency and recovery logic

## Solution

Replace embedded content with skill references:

| Content | Before | After |
|---------|--------|-------|
| INVEST criteria | 15 lines embedded | Skill reference |
| Story format | 10 lines embedded | Skill reference |
| Acceptance criteria formats | 20 lines embedded | Skill reference |
| Idempotency check | 32 lines embedded | Pattern reference |
| Recovery flow | 31 lines embedded | Pattern reference |
| Batch tracking init | 6 lines embedded | Pattern reference |

### Alternatives Considered

1. **Partial refactor**: Only remove INVEST criteria - rejected as insufficient reduction
2. **Aggressive refactor (~100 lines)**: Would remove too much context for command execution

## Changes

- `plugins/requirements-expert/commands/create-stories.md`: -239/+68 lines

## Testing

- [x] markdownlint passes
- [x] Referenced template file exists (`story-template.md`)
- [x] Both referenced skills exist (user-story-creation, shared-patterns)
- [x] Follows established refactor pattern from PR #349

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)