### PR TITLE
refactor: leverage task-breakdown skill in create-tasks command

### DIFF
--- a/plugins/requirements-expert/commands/create-tasks.md
+++ b/plugins/requirements-expert/commands/create-tasks.md
@@ -132,32 +132,12 @@ Handle "Select another story" by restarting from Step 1. Handle "Done" by showin
 
 ### Step 9: Summary & Next Steps
 
-Display batch summary per shared-patterns format:
+Display batch summary per shared-patterns Batch Tracking format with task-specific additions:
 
-```text
-**Task creation complete for Story #[story-num]!**
-
-**Created:** [N] new tasks
-[Group by layer: Frontend, Backend, Data, Testing, Documentation]
-- #[num] - [Task title]
-
-**Updated:** [N] existing tasks (if > 0)
-**Skipped:** [N] duplicates (if > 0)
-**Failed:** [N] tasks (if > 0)
-
-**Suggested execution order:**
-Phase 1: #[num], #[num] (no dependencies)
-Phase 2: #[num] (depends on Phase 1)
-Phase 3: #[num] (testing and documentation)
-
-All tasks linked to Story (#[story-num])
-
-**Next steps:**
-- Review tasks in GitHub Projects
-- Assign tasks to team members
-- Start with Phase 1 tasks
-- Run `/re:status` for project overview
-```
+- Group created tasks by layer (Frontend, Backend, Data, Testing, Documentation)
+- Show suggested execution order by phase (from Step 7)
+- Include parent story link
+- Next steps: Review in GitHub Projects, assign tasks, start Phase 1, run `/re:status`
 
 ## Error Handling
 


### PR DESCRIPTION
## Summary

Refactors `create-tasks.md` to leverage the task-breakdown skill instead of embedding layer taxonomy and methodology directly. This follows the pattern established by `create-stories.md` and aligns with the plugin's design of keeping commands lean while skills contain the domain knowledge.

## Problem

Fixes #340

The command was 370 lines with embedded methodology that duplicated content from the task-breakdown skill:
- Full layer taxonomy (Frontend/Backend/Data/Testing/Documentation) with descriptions
- Prescriptive output format specifications
- Sequencing methodology details
- 40+ line success message format

## Solution

Replaced embedded content with skill references:
- "Apply task-breakdown skill layer methodology" instead of listing all layers
- Reference `Step 5: Sequence and Dependencies` for sequencing
- Reference shared-patterns for error handling and idempotency
- Simplified success message to essential elements

### Changes Made
- Removed 30-line layer taxonomy list
- Condensed Step 2 from ~40 lines to ~8 lines
- Condensed Step 7 from ~15 lines to ~7 lines  
- Simplified Step 9 success message from ~55 lines to ~25 lines
- Removed redundant Notes section
- Kept all functional steps and error handling references

### Alternatives Considered
- **More aggressive reduction**: Could have gone to ~120 lines by removing more context, but this would make the command harder to follow
- **Less reduction**: Could have kept more inline examples, but this would continue duplicating skill content

## Testing

- [x] Markdownlint passes
- [x] Command structure verified
- [x] All step references are valid
- [x] Skill references point to existing sections

## Metrics

| Metric | Before | After | Change |
|--------|--------|-------|--------|
| Line count | 370 | 169 | -54% |
| Insertions | - | 83 | - |
| Deletions | - | 284 | - |

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)