### PR TITLE
fix(ci): exclude deleted files from component validation

### DIFF
--- a/.github/workflows/component-validation.yml
+++ b/.github/workflows/component-validation.yml
@@ -40,11 +40,13 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           # Get list of changed files in this PR, filtered to plugin components
+          # Note: gh pr diff includes deleted files, so we filter to only existing files
           changed_files=$(gh pr diff ${{ github.event.pull_request.number }} --name-only | \
             grep -E '^plugins/requirements-expert/(commands|skills|agents|hooks)/' | \
             grep -v '\-SUGGESTED\.md$' | \
             grep -v '\-BACKUP\.md$' | \
-            grep -v '\-OLD\.md$' || true)
+            grep -v '\-OLD\.md$' | \
+            while read -r file; do [ -f "$file" ] && echo "$file"; done || true)
 
           if [ -z "$changed_files" ]; then
             echo "No plugin component files changed"


### PR DESCRIPTION
## Summary

- Fix component validation workflow to exclude deleted files from validation list
- Resolves failure seen in PR #356 where deleted `requirements-validator.md` caused validation to fail

## Problem

The `gh pr diff --name-only` command includes deleted files in its output. When PR #356 deleted the `requirements-validator.md` agent, the workflow tried to validate the non-existent file and failed with:

```
agents/requirements-validator.md: File does not exist
```

## Solution

Add a filter to check file existence before including in the validation list:

```bash
while read -r file; do [ -f "$file" ] && echo "$file"; done
```

## Test plan

- [ ] Verify workflow passes on this PR (no component files changed, should skip)
- [ ] Future PRs that delete component files should no longer fail validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)