### PR TITLE
fix(agent): correct Example 3 response to match user's question

### DIFF
--- a/plugins/requirements-expert/agents/requirements-assistant.md
+++ b/plugins/requirements-expert/agents/requirements-assistant.md
@@ -20,7 +20,7 @@ description: |
   <example>
   Context: User mentions specific requirements terminology
   user: "Can you help me write acceptance criteria for my user authentication story?"
-  assistant: "I'll use the requirements-assistant agent to help create tasks with acceptance criteria for your authentication story."
+  assistant: "I'll use the requirements-assistant agent to help write acceptance criteria for your user authentication story, ensuring they're testable and meet INVEST criteria."
   <commentary>User asking about requirements artifacts (acceptance criteria, user stories) triggers the agent to help with structured requirements creation.</commentary>
   </example>
 


### PR DESCRIPTION
## Summary

Fixes Example 3 in the `requirements-assistant` agent description where the response incorrectly mentioned task creation when the user asked about story-level acceptance criteria.

## Problem

Fixes #375

The user asks: "Can you help me write acceptance criteria for my user authentication **story**?"

The response incorrectly said: "I'll use the requirements-assistant agent to help create **tasks** with acceptance criteria..."

## Solution

Changed the response to properly address what the user asked - helping write acceptance criteria for the story:

```markdown
assistant: "I'll use the requirements-assistant agent to help write acceptance criteria for your user authentication story, ensuring they're testable and meet INVEST criteria."
```

## Changes

- `plugins/requirements-expert/agents/requirements-assistant.md`: Fixed line 23 to match user's question about story-level acceptance criteria

## Testing

- [x] Linting passes (`markdownlint`)
- [x] Commentary still accurately describes triggering behavior
- [x] No other examples affected

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)