### PR TITLE
feat(agent): add explicit trigger phrases for AI pattern matching

### DIFF
--- a/plugins/requirements-expert/agents/requirements-assistant.md
+++ b/plugins/requirements-expert/agents/requirements-assistant.md
@@ -58,7 +58,26 @@ You are an expert Product Manager and Requirements Engineer specializing in stru
 
 ## Core Responsibilities
 
-1. **Detect Requirements Context**: Recognize planning, design, or requirements-related activities
+1. **Detect Requirements Context**: Trigger when user message contains these patterns:
+
+   **High-confidence triggers** (use agent):
+   - "vision", "epic", "user story", "acceptance criteria"
+   - "requirements", "prioritize features", "MoSCoW"
+   - "break down", "breakdown work", "task breakdown"
+   - "plan the project", "project planning", "roadmap"
+   - "what should I build", "help me plan"
+   - Mentions of `/re:` commands
+
+   **Medium-confidence triggers** (assess context first):
+   - "feature", "functionality", "capability"
+   - "new project", "new app", "build a..."
+   - "what's next", "next steps" (in requirements context)
+
+   **Do NOT trigger for**:
+   - General coding questions ("how do I implement X")
+   - Debugging ("why isn't this working")
+   - Simple status checks ("show me status") - run command directly
+   - Questions about existing code
 2. **Assess Current State**: Check GitHub Project for existing requirements before suggesting actions
 3. **Guide Workflow Progression**: Help users move through the lifecycle in correct order
 4. **Execute Commands**: Run appropriate `/re:*` commands with user consent


### PR DESCRIPTION
## Summary

Adds explicit trigger phrases to the requirements-assistant agent's Core Responsibilities section to improve AI pattern matching consistency.

## Problem

Fixes #378

The current instruction "recognize planning, design, or requirements-related activities" is vague and requires AI inference. This leads to inconsistent triggering across sessions.

## Solution

Replace the vague instruction with explicit patterns organized by confidence level:

### High-confidence triggers (use agent immediately):
- "vision", "epic", "user story", "acceptance criteria"
- "requirements", "prioritize features", "MoSCoW"
- "break down", "breakdown work", "task breakdown"
- "plan the project", "project planning", "roadmap"
- "what should I build", "help me plan"
- Mentions of `/re:` commands

### Medium-confidence triggers (assess context first):
- "feature", "functionality", "capability"
- "new project", "new app", "build a..."
- "what's next", "next steps" (in requirements context)

### Negative patterns (do NOT trigger):
- General coding questions ("how do I implement X")
- Debugging ("why isn't this working")
- Simple status checks ("show me status") - run command directly
- Questions about existing code

## Changes

- `plugins/requirements-expert/agents/requirements-assistant.md`: Updated Core Responsibilities item #1 with explicit trigger patterns

## Testing

- [x] Linting passes
- [x] Pattern structure follows markdown style guide

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)