### PR TITLE
fix(agent): correct INVEST criteria reference in Example 3

### DIFF
--- a/plugins/requirements-expert/agents/requirements-assistant.md
+++ b/plugins/requirements-expert/agents/requirements-assistant.md
@@ -20,7 +20,7 @@ description: |
   <example>
   Context: User mentions specific requirements terminology
   user: "Can you help me write acceptance criteria for my user authentication story?"
-  assistant: "I'll use the requirements-assistant agent to help write acceptance criteria for your user authentication story, ensuring they're testable and meet INVEST criteria."
+  assistant: "I'll use the requirements-assistant agent to help write acceptance criteria for your user authentication story, ensuring they're specific, measurable, and testable."
   <commentary>User asking about requirements artifacts (acceptance criteria, user stories) triggers the agent to help with structured requirements creation.</commentary>
   </example>
 


### PR DESCRIPTION
## Summary

Corrects a technical inaccuracy in the `requirements-assistant` agent where Example 3 incorrectly stated that acceptance criteria should "meet INVEST criteria."

## Problem

Fixes #385

INVEST (Independent, Negotiable, Valuable, Estimable, Small, Testable) is a framework for evaluating **user stories**, not acceptance criteria. Acceptance criteria should be specific, measurable, and testable.

## Solution

Changed the example response from:
> "...ensuring they're testable and meet INVEST criteria."

To:
> "...ensuring they're specific, measurable, and testable."

### Alternatives Considered

None - this is a straightforward terminology correction.

## Changes

- `plugins/requirements-expert/agents/requirements-assistant.md`: Updated Example 3 response text

## Testing

- [x] Verified no other incorrect INVEST references for acceptance criteria in the agent
- [x] Markdownlint passes

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)