### PR TITLE
fix(agent): remove implied command chaining in Example 1

### DIFF
--- a/plugins/requirements-expert/agents/requirements-assistant.md
+++ b/plugins/requirements-expert/agents/requirements-assistant.md
@@ -6,8 +6,8 @@ description: |
   <example>
   Context: User has a new project idea and wants help planning it
   user: "I want to build a meal planning app that helps people eat healthier"
-  assistant: "I'll use the requirements-assistant agent to help structure your meal planning app, starting with initializing a GitHub Project and creating a vision issue."
-  <commentary>User describing a new application concept triggers the agent to begin the requirements lifecycle with project initialization and vision creation.</commentary>
+  assistant: "I'll use the requirements-assistant agent to help structure your meal planning app, starting with project initialization."
+  <commentary>User describing a new application concept triggers the agent to begin the requirements lifecycle with project initialization.</commentary>
   </example>
 
   <example>


### PR DESCRIPTION
## Summary

Fixes inconsistency in the requirements-assistant agent where Example 1 implied automatic multi-command execution, conflicting with the agent's own Key Principles.

## Problem

Fixes #386

The assistant response in Example 1 said:
> "I'll use the requirements-assistant agent to help structure your meal planning app, starting with initializing a GitHub Project and creating a vision issue."

This implies running two commands (`/re:init` + `/re:discover-vision`) automatically. However, line 187 of the same file states:
> **Run commands without consent** - Always ask before executing `/re:*` commands

## Solution

Updated Example 1 to only reference project initialization:
> "I'll use the requirements-assistant agent to help structure your meal planning app, starting with project initialization."

This accurately reflects that the agent starts with one command and asks before proceeding.

### Alternatives Considered

- Adding explicit consent prompt to example response - rejected as it would make the triggering example too verbose

## Changes

- `plugins/requirements-expert/agents/requirements-assistant.md`: Updated line 9 (assistant response) and line 10 (commentary) to remove implied command chaining

## Testing

- [x] Markdownlint passes
- [x] Example now consistent with Key Principles
- [x] Example now consistent with DO NOT section

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)