### PR TITLE
refactor(agent): convert blockquote templates to code blocks

### DIFF
--- a/plugins/requirements-expert/agents/requirements-assistant.md
+++ b/plugins/requirements-expert/agents/requirements-assistant.md
@@ -251,28 +251,32 @@ Use these templates for consistent workflow continuation:
 
 **After successful command:**
 
-> ✅ [Summary of what was created]
->
-> Would you like to continue with `{next_command}` to {description}?
+```text
+✅ [Summary of what was created]
+
+Would you like to continue with {next_command} to {description}?
+```
 
 **After completing a phase:**
 
-> 🎉 All {phase}s created! Your project now has:
->
-> - {count} Vision
-> - {count} Epics
-> - {count} Stories
-> - {count} Tasks
->
-> **Suggested next steps:**
->
-> 1. `{primary_next}` - {description}
-> 2. `{secondary_option}` - {description}
+```text
+🎉 All {phase}s created! Your project now has:
+- {count} Vision
+- {count} Epics
+- {count} Stories
+- {count} Tasks
+
+Suggested next steps:
+1. {primary_next} - {description}
+2. {secondary_option} - {description}
+```
 
 **When prerequisites missing:**
 
-> I'd like to help with {requested}, but {prerequisite} doesn't exist yet.
-> Should I run `{prereq_command}` first?
+```text
+I'd like to help with {requested}, but {prerequisite} doesn't exist yet.
+Should I run {prereq_command} first?
+```
 
 ## Error Handling
 


### PR DESCRIPTION
## Summary
- Convert 3 blockquote templates to fenced code blocks in requirements-assistant agent
- Improves rendering consistency and semantic clarity

## Problem
Fixes #387

Blockquote (`>`) syntax renders poorly when templates contain embedded markdown formatting. These are templates, not actual quotes—code blocks are semantically more appropriate.

## Solution
Convert all continuation prompt templates from blockquote syntax to `text` fenced code blocks:
- "After successful command" template
- "After completing a phase" template  
- "When prerequisites missing" template

### Alternatives Considered
- Keep blockquotes: Poor rendering with embedded markdown
- Use markdown code blocks: Less visual distinction than `text` blocks

## Changes
- `plugins/requirements-expert/agents/requirements-assistant.md`: Lines 254-279

## Testing
- [x] All 3 blockquote templates converted to code blocks
- [x] Template content preserved (placeholders, structure)
- [x] markdownlint passes
- [x] Visual rendering improved

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)