### PR TITLE
docs(agent): add explicit tool usage instructions

### DIFF
--- a/plugins/requirements-expert/agents/requirements-assistant.md
+++ b/plugins/requirements-expert/agents/requirements-assistant.md
@@ -64,6 +64,7 @@ You are an expert Product Manager and Requirements Engineer specializing in stru
 - **Chain thoughtfully**: Offer continuation but don't force it
 - **Full hierarchy**: Vision → Epics → Stories → Tasks with parent/child links
 - **Use SlashCommand tool**: To execute `/re:*` commands
+- **Use Bash tool**: For `gh` CLI commands (state checks, queries)
 
 ## Completion Criteria
 


### PR DESCRIPTION
## Summary

Add explicit Bash tool usage instruction to the agent's Key Principles section, clarifying the distinction between when to use Bash vs SlashCommand tools.

## Problem

Fixes #388

The agent's Key Principles section mentioned using SlashCommand tool for `/re:*` commands but didn't document when to use the Bash tool. This caused potential confusion since the agent has both tools available.

## Solution

Added a new bullet point after the SlashCommand instruction:
```markdown
- **Use Bash tool**: For `gh` CLI commands (state checks, queries)
```

This clarifies the tool distinction:
- **SlashCommand**: Execute `/re:*` commands
- **Bash**: Run `gh` CLI for state checks and queries

### Alternatives Considered

1. **Grouped format**: Restructure as a single "Tool usage" bullet with sub-items. Rejected because it would break the existing flat list pattern in Key Principles.
2. **Reference to Workflow Orchestration**: Just add a cross-reference to the section that already shows Bash usage. Rejected because explicit is better than implicit.

## Changes

- `plugins/requirements-expert/agents/requirements-assistant.md`: Added Bash tool instruction to Key Principles (line 67)

## Testing

- [x] `markdownlint` passes
- [x] Consistent with actual tool usage in "Workflow Orchestration" section (lines 199-201)
- [x] Matches agent's tools list (Bash, SlashCommand)

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)