### PR TITLE
chore(agent): apply low-priority enhancements to requirements-assistant

### DIFF
--- a/plugins/requirements-expert/agents/requirements-assistant.md
+++ b/plugins/requirements-expert/agents/requirements-assistant.md
@@ -46,6 +46,11 @@ color: blue
 # This agent only uses `gh` CLI commands in practice - see "Workflow Orchestration"
 # section. Restriction must be enforced at project level if required.
 # Reference: https://github.com/sjnims/requirements-expert/issues/370
+#
+# NOTE: Read tool intentionally omitted. This agent orchestrates workflow by
+# invoking /re:* commands (which have their own Read access for templates).
+# The agent checks state via `gh` CLI, not by reading files directly.
+# Reference: https://github.com/sjnims/requirements-expert/issues/390
 tools:
   - Bash
   - AskUserQuestion
@@ -143,6 +148,8 @@ All requirements stored as GitHub issues in GitHub Projects with parent/child hi
 | Proactive validation | Stories complete for epic | Suggest `/re:review` before proceeding |
 | Proactive validation | Tasks complete for story | Suggest `/re:review` before development |
 
+_For state-based action mapping (without user intent context), see [Workflow Orchestration Step 2](#step-2-determine-next-action)._
+
 ## Quality Standards
 
 Before completing any phase, verify:
@@ -201,6 +208,8 @@ gh project item-list [project-number] --format json
 | Tasks incomplete | `/re:create-tasks` |
 | Not prioritized | `/re:prioritize` |
 | Quality check needed | `/re:review` |
+
+_For intent-based decision making (with user context), see [Decision Rules](#decision-rules)._
 
 ### Step 3: Execute with User Consent
 
@@ -279,7 +288,7 @@ Should I run {prereq_command} first?
 |----------|----------|
 | User wants to skip phases | Explain dependencies: "Stories need epics as parents. Should I help create epics first?" |
 | User asks to edit existing | Guide to GitHub UI or `gh issue edit` - agent creates, doesn't modify |
-| Multiple projects in repo | List projects, ask user to choose: "I found 2 projects. Which one?" |
+| Multiple projects in repo | List projects, ask user to choose (see [detailed handling](#multiple-projects) below) |
 | Interrupted workflow | Check state, summarize what exists, offer to continue from last point |
 | User asks to delete | Explain: "I can help create requirements. For deletion, use `gh issue close #N`" |
 | Conflicting requirements | Flag the conflict, ask user to clarify before proceeding |


### PR DESCRIPTION
## Summary

- Document Read tool omission decision with rationale
- Add cross-references between Decision Rules and Workflow Orchestration tables  
- Link edge cases table entry to detailed Multiple Projects subsection

## Problem

Fixes #390

The issue identified three minor enhancements for the requirements-assistant agent:
1. **Enhancement A**: Clarify Read tool decision
2. **Enhancement B**: Tables had overlap without cross-references
3. **Enhancement C**: Edge cases table didn't reference detailed Multiple Projects subsection

## Solution

### Enhancement A: Read Tool Decision
Added a NOTE in the frontmatter explaining why Read tool is intentionally omitted:
- Agent orchestrates workflow via `/re:*` commands (which have their own Read access)
- State checking done via `gh` CLI, not file reading
- Maintains orchestration-only purpose

### Enhancement B: Table Cross-References
Added cross-reference notes linking:
- Decision Rules → Workflow Orchestration Step 2 (for state-based mapping)
- Workflow Orchestration Step 2 → Decision Rules (for intent-based decisions)

### Enhancement C: Multiple Projects Reference
Updated edge cases table to link to the detailed Multiple Projects subsection instead of inline summary.

### Alternatives Considered
- **Enhancement A**: Could have added Read tool, but agent doesn't need direct file access
- **Enhancement B**: Could have merged tables, but they serve different purposes (intent vs state)
- **Enhancement C**: Could have condensed Multiple Projects, but detail is valuable

## Changes

- `plugins/requirements-expert/agents/requirements-assistant.md`: Added 10 lines

## Testing

- [x] `markdownlint` passes
- [x] Cross-reference links verified (anchor format matches heading)

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)