### PR TITLE
docs: add marketplace install instructions and fix HTML elements list

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -334,7 +334,7 @@ markdownlint '**/*.md' --ignore node_modules --fix
 - No line length limits (MD013 disabled)
 - Fenced code blocks (not indented)
 - Underscores for emphasis (`_italic_`), asterisks for bold (`**bold**`)
-- Allow HTML elements: `<example>`, `<commentary>`, `<details>`, `<summary>`, `<br>`, `<invoke>`, `<parameter>`
+- Allow HTML elements: `<example>`, `<commentary>`, `<details>`, `<summary>`, `<br>`, `<p>`, `<img>`, `<invoke>`, `<parameter>`
 
 **VS Code integration**: Markdown validation is enabled (see `.vscode/settings.json`)
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,13 @@ cc --plugin-dir plugins/requirements-expert
 
 ### From Marketplace
 
-**Note:** This plugin is currently distributed via GitHub. Marketplace publishing is planned for future releases.
+In Claude Code, run:
+
+```
+/install-plugin sjnims/requirements-expert
+```
+
+This installs the plugin from the GitHub marketplace.
 
 ## Quick Start
 


### PR DESCRIPTION
## Summary

- Add `/install-plugin sjnims/requirements-expert` command to README.md installation section
- Align CLAUDE.md allowed HTML elements with `.markdownlint.json` config (add `<p>` and `<img>` tags)

## Test plan

- [x] Verify README installation instructions are clear
- [x] Verify CLAUDE.md HTML elements match `.markdownlint.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)