### PR TITLE
chore: prepare release v0.5.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,13 +6,13 @@
   },
   "metadata": {
     "description": "Official requirements-expert plugin marketplace for requirements-expert Claude Code plugin",
-    "version": "0.5.0"
+    "version": "0.5.1"
   },
   "plugins": [
     {
       "name": "requirements-expert",
       "description": "A comprehensive requirements management plugin that guides users through the full requirements lifecycle (vision → epics → user stories → tasks) using GitHub Projects for complete traceability and collaboration",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "author": {
         "name": "Steve Nims",
         "url": "https://github.com/sjnims",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.1] - 2025-12-07
+
+### Changed
+
+- **Hook trigger precision improved** - narrowed criteria from broad "planning/designing" to explicit requirements terminology (#406)
+- **"Already engaged" detection** added to avoid redundant plugin suggestions when user references `/re:` commands (#406)
+- **Hook aligned with Claude Code best practices** - restructured for optimal AI consumption (#402, #405)
+
+### Documentation
+
+- **Cleaned up unused HTML elements** from CLAUDE.md (`<details>`, `<summary>`, `<br>` tags) (#407)
+- **Updated version references** in documentation to v0.5.0 (#407)
+- **Updated SECURITY.md** supported version from 0.1.x to 0.5.x (#407)
+- **Fixed CONTRIBUTING.md** allowed-tools example to use `Bash(gh:*)` (#407)
+
 ## [0.5.0] - 2025-12-07
 
 ### Added
@@ -322,7 +337,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `plugin.json` - Plugin metadata and configuration (v0.1.0)
 - `marketplace.json` - Marketplace distribution metadata (v0.1.0)
 
-[Unreleased]: https://github.com/sjnims/requirements-expert/compare/v0.5.0...HEAD
+[Unreleased]: https://github.com/sjnims/requirements-expert/compare/v0.5.1...HEAD
+[0.5.1]: https://github.com/sjnims/requirements-expert/compare/v0.5.0...v0.5.1
 [0.5.0]: https://github.com/sjnims/requirements-expert/compare/v0.4.0...v0.5.0
 [0.4.0]: https://github.com/sjnims/requirements-expert/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/sjnims/requirements-expert/compare/v0.2.0...v0.3.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@ The requirements-expert plugin is a **Claude Code plugin** that guides users thr
 
 ## Quick Reference
 
-**Current Version**: v0.5.0 (see [CHANGELOG.md](CHANGELOG.md) for release history)
+**Current Version**: v0.5.1 (see [CHANGELOG.md](CHANGELOG.md) for release history)
 
 **Plugin Root**: `plugins/requirements-expert/` (not repository root)
 

--- a/plugins/requirements-expert/.claude-plugin/plugin.json
+++ b/plugins/requirements-expert/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "requirements-expert",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "A comprehensive requirements management plugin that guides users through the full requirements lifecycle (vision → epics → user stories → tasks) using GitHub Projects for complete traceability and collaboration",
   "author": {
     "name": "Steve Nims",


### PR DESCRIPTION
## Summary

- Version bump to v0.5.1
- Updated CHANGELOG.md with release notes
- Hook improvements for better trigger precision

## Changes in v0.5.1

### Changed
- **Hook trigger precision improved** - narrowed criteria from broad "planning/designing" to explicit requirements terminology (#406)
- **"Already engaged" detection** added to avoid redundant plugin suggestions when user references `/re:` commands (#406)
- **Hook aligned with Claude Code best practices** - restructured for optimal AI consumption (#402, #405)

### Documentation
- **Cleaned up unused HTML elements** from CLAUDE.md (#407)
- **Updated version references** in documentation to v0.5.0 (#407)
- **Updated SECURITY.md** supported version from 0.1.x to 0.5.x (#407)
- **Fixed CONTRIBUTING.md** allowed-tools example to use `Bash(gh:*)` (#407)

## Checklist

- [x] Version updated in plugin.json, marketplace.json, CLAUDE.md
- [x] CHANGELOG.md updated with release notes
- [x] Markdownlint passes
- [x] Plugin tested locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)