### PR TITLE
chore(deps): update claude-code-action to v1.0.26

### DIFF
--- a/.github/workflows/ci-failure-analysis.yml
+++ b/.github/workflows/ci-failure-analysis.yml
@@ -42,7 +42,7 @@ jobs:
           fetch-depth: 1
 
       - name: Analyze failure with Claude
-        uses: anthropics/claude-code-action@d7b6d50442a89f005016e778bf825a72ef582525 # v1.0.25
+        uses: anthropics/claude-code-action@94e310eb2ce38c5bff2934c5858caf6cbde5ac01 # v1.0.26
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: |

--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -41,7 +41,7 @@ jobs:
         run: npm install -g markdownlint-cli
 
       - name: Review PR with Claude
-        uses: anthropics/claude-code-action@d7b6d50442a89f005016e778bf825a72ef582525 # v1.0.25
+        uses: anthropics/claude-code-action@94e310eb2ce38c5bff2934c5858caf6cbde5ac01 # v1.0.26
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           mode: agent

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -57,7 +57,7 @@ jobs:
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@d7b6d50442a89f005016e778bf825a72ef582525 # v1.0.25
+        uses: anthropics/claude-code-action@94e310eb2ce38c5bff2934c5858caf6cbde5ac01 # v1.0.26
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           use_commit_signing: true

--- a/.github/workflows/component-validation.yml
+++ b/.github/workflows/component-validation.yml
@@ -65,7 +65,7 @@ jobs:
 
       - name: Validate plugin components
         if: steps.changed-files.outputs.has_changes == 'true'
-        uses: anthropics/claude-code-action@d7b6d50442a89f005016e778bf825a72ef582525 # v1.0.25
+        uses: anthropics/claude-code-action@94e310eb2ce38c5bff2934c5858caf6cbde5ac01 # v1.0.26
         id: validate
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/.github/workflows/semantic-labeler.yml
+++ b/.github/workflows/semantic-labeler.yml
@@ -35,7 +35,7 @@ jobs:
           fetch-depth: 1
 
       - name: Label issue with Claude
-        uses: anthropics/claude-code-action@d7b6d50442a89f005016e778bf825a72ef582525 # v1.0.25
+        uses: anthropics/claude-code-action@94e310eb2ce38c5bff2934c5858caf6cbde5ac01 # v1.0.26
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: |
@@ -129,7 +129,7 @@ jobs:
           fetch-depth: 1
 
       - name: Label PR with Claude
-        uses: anthropics/claude-code-action@d7b6d50442a89f005016e778bf825a72ef582525 # v1.0.25
+        uses: anthropics/claude-code-action@94e310eb2ce38c5bff2934c5858caf6cbde5ac01 # v1.0.26
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: |

--- a/.github/workflows/version-check.yml
+++ b/.github/workflows/version-check.yml
@@ -30,7 +30,7 @@ jobs:
           fetch-depth: 1
 
       - name: Check version consistency
-        uses: anthropics/claude-code-action@d7b6d50442a89f005016e778bf825a72ef582525 # v1.0.25
+        uses: anthropics/claude-code-action@94e310eb2ce38c5bff2934c5858caf6cbde5ac01 # v1.0.26
         id: version-check
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/.github/workflows/weekly-maintenance.yml
+++ b/.github/workflows/weekly-maintenance.yml
@@ -28,7 +28,7 @@ jobs:
           fetch-depth: 1
 
       - name: Generate maintenance report
-        uses: anthropics/claude-code-action@d7b6d50442a89f005016e778bf825a72ef582525 # v1.0.25
+        uses: anthropics/claude-code-action@94e310eb2ce38c5bff2934c5858caf6cbde5ac01 # v1.0.26
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: |


### PR DESCRIPTION
## Summary

- Update `anthropics/claude-code-action` from v1.0.25 to v1.0.26 across all 7 workflow files (8 total occurrences)

## Files Updated

| Workflow | Occurrences |
|----------|-------------|
| `claude.yml` | 1 |
| `claude-pr-review.yml` | 1 |
| `ci-failure-analysis.yml` | 1 |
| `component-validation.yml` | 1 |
| `semantic-labeler.yml` | 2 |
| `version-check.yml` | 1 |
| `weekly-maintenance.yml` | 1 |

## Test plan

- [ ] CI workflows pass
- [ ] No remaining v1.0.25 references

🤖 Generated with [Claude Code](https://claude.com/claude-code)