### PR TITLE
chore(deps): update actions/checkout to v6.0.2

### DIFF
--- a/.github/workflows/ci-failure-analysis.yml
+++ b/.github/workflows/ci-failure-analysis.yml
@@ -37,7 +37,7 @@ jobs:
       # Checkout default branch for config files (NOT head_sha to avoid untrusted code)
       # Config files like .markdownlint.json rarely change and base repo version is authoritative
       - name: Checkout repository
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
 

--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -28,7 +28,7 @@ jobs:
       actions: read
     steps:
       - name: Checkout repository
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 1
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -46,7 +46,7 @@ jobs:
       actions: read # Required by claude-code-action to access workflow run data
     steps:
       - name: Checkout repository
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 1
 

--- a/.github/workflows/component-validation.yml
+++ b/.github/workflows/component-validation.yml
@@ -30,7 +30,7 @@ jobs:
       actions: read
     steps:
       - name: Checkout repository
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 

--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -21,7 +21,7 @@ jobs:
       issues: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Restore lychee cache
         uses: actions/cache@9255dc7a253b0ccc959486e2bca901246202afeb # v5.0.1

--- a/.github/workflows/markdownlint.yml
+++ b/.github/workflows/markdownlint.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Run markdownlint
         uses: articulate/actions-markdownlint@17b8abe7407cd17590c006ecc837c35e1ac3ed83 # v1.1.0

--- a/.github/workflows/semantic-labeler.yml
+++ b/.github/workflows/semantic-labeler.yml
@@ -30,7 +30,7 @@ jobs:
       actions: read
     steps:
       - name: Checkout repository
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 1
 
@@ -124,7 +124,7 @@ jobs:
       actions: read
     steps:
       - name: Checkout repository
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 1
 

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -23,7 +23,7 @@ jobs:
       issues: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Sync labels
         # Uses GITHUB_TOKEN automatically (provided by GitHub Actions)

--- a/.github/workflows/validate-workflows.yml
+++ b/.github/workflows/validate-workflows.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Run actionlint
         uses: raven-actions/actionlint@963d4779ef039e217e5d0e6fd73ce9ab7764e493 # v2.1.0

--- a/.github/workflows/version-check.yml
+++ b/.github/workflows/version-check.yml
@@ -25,7 +25,7 @@ jobs:
       id-token: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 1
 

--- a/.github/workflows/weekly-maintenance.yml
+++ b/.github/workflows/weekly-maintenance.yml
@@ -23,7 +23,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 1
 


### PR DESCRIPTION
## Description

Update `actions/checkout` from v6.0.1 to v6.0.2 across all 11 workflow files. This keeps our GitHub Actions pinned to the latest release SHA for security best practices.

**Changes:**
- Old: `actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1`
- New: `actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2`

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to README, CLAUDE.md, or component docs)
- [ ] Refactoring (code change that neither fixes a bug nor adds a feature)
- [ ] Test (adding or updating tests)
- [x] Configuration change (changes to .markdownlint.json, plugin.json, etc.)

## Component(s) Affected

- [ ] Commands (`/re:*`)
- [ ] Skills (methodology and best practices)
- [ ] Agents (requirements-assistant)
- [ ] Hooks (UserPromptSubmit)
- [ ] Documentation (README.md, CLAUDE.md, SECURITY.md)
- [ ] Configuration (.markdownlint.json, plugin.json, marketplace.json)
- [ ] Issue/PR templates
- [x] Other (please specify): GitHub Actions workflows

## Motivation and Context

Keeping GitHub Actions pinned to the latest SHA ensures we have the latest bug fixes and security patches. All 11 other actions in the repository were already up to date.

## How Has This Been Tested?

**Test Configuration**:
- GitHub CLI version: `gh 2.x`
- OS: macOS

**Test Steps**:
1. Verified current action SHAs using `/action-sha` skill
2. Compared against latest releases
3. Updated all occurrences using replace-all edit

## Checklist

### General

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings or errors

### Documentation

- [x] N/A - no documentation changes needed

### Markdown

- [x] N/A - only YAML workflow files changed

### Testing

- [x] Verified all workflow files have consistent SHA
- [x] Verified SHA matches the v6.0.2 release tag

## Additional Notes

All other actions in the repository were already at their latest versions:
- actions/first-interaction@v3.1.0 ✅
- actions/cache@v5.0.1 ✅
- actions/stale@v10.1.1 ✅
- actions/setup-node@v6.1.0 ✅
- lycheeverse/lychee-action@v2.7.0 ✅
- peter-evans/create-issue-from-file@v6.0.0 ✅
- articulate/actions-markdownlint@v1.1.0 ✅
- EndBug/label-sync@v2.3.3 ✅
- raven-actions/actionlint@v2.1.0 ✅
- anthropics/claude-code-action@v1.0.29 ✅